### PR TITLE
Add games (Tetris, Snake), 5 new animations, and multiple bugfixes

### DIFF
--- a/LedStrip.h
+++ b/LedStrip.h
@@ -2113,6 +2113,7 @@ public:
           p.display = true;
           _pPixelContainerOutput->pixelsEdge[e] = p;
         }
+        copyForeground();
       }
         if (--_flashTimer <= 0) {
           _fadeProgress = 0;

--- a/LedStrip.h
+++ b/LedStrip.h
@@ -1378,14 +1378,16 @@ public:
       Pixel head = Pixel(RgbColor(
         (uint8_t)((uint16_t)200 * bMax / 255), bMax,
         (uint8_t)((uint16_t)200 * bMax / 255)));
-      Pixel trail = Pixel(RgbColor(0, bMax, 0));
       for (int r = _matrixColumn[c]; r > _matrixColumn[c] - _matrixColumnSize[c]; r--) {
         int dist = _matrixColumn[c] - r;
         if (dist == 0) {
           _pPixelContainerOutput->pixelsArray.setPixel(head, r, c);
         } else {
-          _pPixelContainerOutput->pixelsArray.setPixel(trail, r, c);
-          if (dist >= 5) trail.color.Darken(35);
+          // Fade proportionally over the full trail length so the tail remains
+          // visible at any animBrightnessMax value (avoids absolute Darken going
+          // to black too fast at low brightness)
+          uint8_t g = (uint8_t)((uint16_t)bMax * (_matrixColumnSize[c] - dist) / _matrixColumnSize[c]);
+          _pPixelContainerOutput->pixelsArray.setPixel(Pixel(RgbColor(0, g, 0)), r, c);
         }
       }
 

--- a/LedStrip.h
+++ b/LedStrip.h
@@ -19,6 +19,7 @@
 //typedef NeoPixelBrightnessBus<NeoGrbFeature, NeoEsp8266AsyncUart1Ws2813Method> MyNeoPixelBrightnessBus;
 typedef NeoPixelBrightnessBus<NeoGrbFeature, NeoEsp8266Uart1Ws2813Method> MyNeoPixelBrightnessBus;
 
+
 class Pixel
 {
 public:
@@ -92,32 +93,67 @@ struct PixelsContainer
   bool hasChanged;
 };
 
+
+
 class LedConfiguration {
 public:
   virtual int ledsByPixelForMatrix() = 0;
   virtual int ledsByPixelForEdges() = 0;
   virtual int ledsNumber() = 0;
   virtual String getName() = 0;
-  virtual const uint16_t *getLedsMatrixId(int row, int col) = 0;
-  virtual const uint16_t *getLedsEdgeId(int n) = 0;
+  virtual const uint8_t *getLedsMatrixId(int row, int col) = 0;
+  virtual const uint8_t *getLedsEdgeId(int n) = 0;
   virtual ~LedConfiguration() {}
 };
 
 class LedConfiguration40x40 : public LedConfiguration {
 private:
-  const uint16_t _matchingPixelsMatrix[NROW][NCOL][1] = {
-    { { 0  }, { 1  }, { 5  }, { 6  }, { 14 }, { 15 }, { 27 }, { 28  }, { 44  }, { 45  }, { 64  } },
-    { { 2  }, { 4  }, { 7  }, { 13 }, { 16 }, { 26 }, { 29 }, { 43  }, { 46  }, { 63  }, { 65  } },
-    { { 3  }, { 8  }, { 12 }, { 17 }, { 25 }, { 30 }, { 42 }, { 47  }, { 62  }, { 66  }, { 81  } },
-    { { 9  }, { 11 }, { 18 }, { 24 }, { 31 }, { 41 }, { 48 }, { 61  }, { 67  }, { 80  }, { 82  } },
-    { { 10 }, { 19 }, { 23 }, { 32 }, { 40 }, { 49 }, { 60 }, { 68  }, { 79  }, { 83  }, { 94  } },
-    { { 20 }, { 22 }, { 33 }, { 39 }, { 50 }, { 59 }, { 69 }, { 78  }, { 84  }, { 93  }, { 95  } },
-    { { 21 }, { 34 }, { 38 }, { 51 }, { 58 }, { 70 }, { 77 }, { 85  }, { 92  }, { 96  }, { 103 } },
-    { { 35 }, { 37 }, { 52 }, { 57 }, { 71 }, { 76 }, { 86 }, { 91  }, { 97  }, { 102 }, { 104 } },
-    { { 36 }, { 53 }, { 56 }, { 72 }, { 75 }, { 87 }, { 90 }, { 98  }, { 101 }, { 105 }, { 108 } },
-    { { 54 }, { 55 }, { 73 }, { 74 }, { 88 }, { 89 }, { 99 }, { 100 }, { 106 }, { 107 }, { 109 } }
+
+// version damien
+  const uint8_t _matchingPixelsMatrix[NROW][NCOL][1] = {
+    { { 55 }, { 54 }, { 36 }, { 35 }, { 21 }, { 20 }, { 10 }, { 9   }, { 3   }, { 2   }, { 0   } },
+    { { 73 }, { 56 }, { 53 }, { 37 }, { 34 }, { 22 }, { 19 }, { 11  }, { 8   }, { 4   }, { 1   } },
+    { { 74 }, { 72 }, { 57 }, { 52 }, { 38 }, { 33 }, { 23 }, { 18  }, { 12  }, { 7   }, { 5   } },
+    { { 88 }, { 75 }, { 71 }, { 58 }, { 51 }, { 39 }, { 32 }, { 24  }, { 17  }, { 13  }, { 6   } },
+    { { 89 }, { 87 }, { 76 }, { 70 }, { 59 }, { 50 }, { 40 }, { 31  }, { 25  }, { 16  }, { 14  } },
+    { { 99 }, { 90 }, { 86 }, { 77 }, { 69 }, { 60 }, { 49 }, { 41  }, { 30  }, { 26  }, { 15  } },
+    { { 100}, { 98 }, { 91 }, { 85 }, { 78 }, { 68 }, { 61 }, { 48  }, { 42  }, { 29  }, { 27  } },
+    { { 106}, { 101}, { 97 }, { 92 }, { 84 }, { 79 }, { 67 }, { 62  }, { 47  }, { 43  }, { 28  } },
+    { { 107}, { 105}, { 102}, { 96 }, { 93 }, { 83 }, { 80 }, { 66  }, { 63  }, { 46  }, { 44  } },
+    { { 109}, { 108}, { 104}, { 103}, { 95 }, { 94 }, { 82 }, { 81 }, { 65  }, { 64  }, { 45  } }
   };
-  const uint16_t _matchingPixelsEdge[NEDGE][1] = { { 112 }, { 111 }, { 110 }, { 113 } };
+  const uint8_t _matchingPixelsEdge[NEDGE][1] = { { 113 }, { 112 }, { 111 }, { 110 } };
+
+// verison originale
+  //const uint8_t _matchingPixelsMatrix[NROW][NCOL][1] = {
+    //{ { 0  }, { 1  }, { 5  }, { 6  }, { 14 }, { 15 }, { 27 }, { 28  }, { 44  }, { 45  }, { 64  } },
+    //{ { 2  }, { 4  }, { 7  }, { 13 }, { 16 }, { 26 }, { 29 }, { 43  }, { 46  }, { 63  }, { 65  } },
+    //{ { 3  }, { 8  }, { 12 }, { 17 }, { 25 }, { 30 }, { 42 }, { 47  }, { 62  }, { 66  }, { 81  } },
+    //{ { 9  }, { 11 }, { 18 }, { 24 }, { 31 }, { 41 }, { 48 }, { 61  }, { 67  }, { 80  }, { 82  } },
+    //{ { 10 }, { 19 }, { 23 }, { 32 }, { 40 }, { 49 }, { 60 }, { 68  }, { 79  }, { 83  }, { 94  } },
+    //{ { 20 }, { 22 }, { 33 }, { 39 }, { 50 }, { 59 }, { 69 }, { 78  }, { 84  }, { 93  }, { 95  } },
+    //{ { 21 }, { 34 }, { 38 }, { 51 }, { 58 }, { 70 }, { 77 }, { 85  }, { 92  }, { 96  }, { 103 } },
+    //{ { 35 }, { 37 }, { 52 }, { 57 }, { 71 }, { 76 }, { 86 }, { 91  }, { 97  }, { 102 }, { 104 } },
+    //{ { 36 }, { 53 }, { 56 }, { 72 }, { 75 }, { 87 }, { 90 }, { 98  }, { 101 }, { 105 }, { 108 } },
+    //{ { 54 }, { 55 }, { 73 }, { 74 }, { 88 }, { 89 }, { 99 }, { 100 }, { 106 }, { 107 }, { 109 } }
+  //};
+  //const uint8_t _matchingPixelsEdge[NEDGE][1] = { { 112 }, { 111 }, { 110 }, { 113 } };
+
+// verison lina et blandine
+ // const uint8_t _matchingPixelsMatrix[NROW][NCOL][1] = {
+   // { { 0  }, { 1  }, { 5  }, { 6  }, { 14 }, { 15 }, { 27 }, { 28  }, { 44  }, { 45  }, { 64  } },
+    //{ { 2  }, { 4  }, { 7  }, { 13 }, { 16 }, { 26 }, { 29 }, { 43  }, { 46  }, { 63  }, { 65  } },
+    //{ { 3  }, { 8  }, { 12 }, { 17 }, { 25 }, { 30 }, { 42 }, { 47  }, { 62  }, { 66  }, { 81  } },
+    //{ { 9  }, { 11 }, { 18 }, { 24 }, { 31 }, { 41 }, { 48 }, { 61  }, { 67  }, { 80  }, { 82  } },
+    //{ { 10 }, { 19 }, { 23 }, { 32 }, { 40 }, { 49 }, { 60 }, { 68  }, { 79  }, { 83  }, { 94  } },
+    //{ { 20 }, { 22 }, { 33 }, { 39 }, { 50 }, { 59 }, { 69 }, { 78  }, { 84  }, { 93  }, { 95  } },
+    //{ { 21 }, { 34 }, { 38 }, { 51 }, { 58 }, { 70 }, { 77 }, { 85  }, { 92  }, { 96  }, { 103 } },
+    //{ { 35 }, { 37 }, { 52 }, { 57 }, { 71 }, { 76 }, { 86 }, { 91  }, { 97  }, { 102 }, { 104 } },
+    //{ { 36 }, { 53 }, { 56 }, { 72 }, { 75 }, { 87 }, { 90 }, { 98  }, { 101 }, { 105 }, { 108 } },
+    //{ { 54 }, { 55 }, { 73 }, { 74 }, { 88 }, { 89 }, { 99 }, { 100 }, { 106 }, { 107 }, { 109 } }
+  //};
+  //const uint8_t _matchingPixelsEdge[NEDGE][1] = { { 112 }, { 113 }, { 110 }, { 111 } };
+  
 
 public:
   virtual String getName()
@@ -140,7 +176,7 @@ public:
     return (NROW * NCOL) + NEDGE;
   }
 
-  const uint16_t *getLedsMatrixId(int row, int col)
+  const uint8_t *getLedsMatrixId(int row, int col)
   {
     if (row < 0) return NULL;
     if (col < 0) return NULL;
@@ -150,7 +186,7 @@ public:
     return _matchingPixelsMatrix[row][col];
   }
 
-  const uint16_t *getLedsEdgeId(int n)
+  const uint8_t *getLedsEdgeId(int n)
   {
     if (n < 0) return NULL;
     if (n > NEDGE - 1) return NULL;
@@ -161,7 +197,7 @@ public:
 
 class LedConfiguration100x100_1 : public LedConfiguration {
 private:
-  const uint16_t _matchingPixelsMatrix[NROW][NCOL][1] = {
+  const uint8_t _matchingPixelsMatrix[NROW][NCOL][1] = {
     { { 21  }, { 19  }, { 17  }, { 15  }, { 13  }, { 11  }, { 9   }, { 7   }, { 5   }, { 3   }, { 1   } },
     { { 24  }, { 26  }, { 28  }, { 30  }, { 32  }, { 34  }, { 36  }, { 38  }, { 40  }, { 42  }, { 44  } },
     { { 67  }, { 65  }, { 63  }, { 61  }, { 59  }, { 57  }, { 55  }, { 53  }, { 51  }, { 49  }, { 47  } },
@@ -173,7 +209,7 @@ private:
     { { 205 }, { 203 }, { 201 }, { 199 }, { 197 }, { 195 }, { 193 }, { 191 }, { 189 }, { 187 }, { 185 } },
     { { 208 }, { 210 }, { 212 }, { 214 }, { 216 }, { 218 }, { 220 }, { 222 }, { 224 }, { 226 }, { 228 } }
   };
-  const uint16_t _matchingPixelsEdge[NEDGE][1] = { { 232 }, { 231 }, { 230 }, { 233 } };
+  const uint8_t _matchingPixelsEdge[NEDGE][1] = { { 232 }, { 231 }, { 230 }, { 233 } };
 
 public:
   virtual String getName()
@@ -196,7 +232,7 @@ public:
     return (NROW * 23) + NEDGE;
   }
 
-  const uint16_t *getLedsMatrixId(int row, int col)
+  const uint8_t *getLedsMatrixId(int row, int col)
   {
     if (row < 0) return NULL;
     if (col < 0) return NULL;
@@ -206,7 +242,7 @@ public:
     return _matchingPixelsMatrix[row][col];
   }
 
-  const uint16_t *getLedsEdgeId(int n)
+  const uint8_t *getLedsEdgeId(int n)
   {
     if (n < 0) return NULL;
     if (n > NEDGE - 1) return NULL;
@@ -217,7 +253,7 @@ public:
 
 class LedConfiguration100x100_2 : public LedConfiguration {
 private:
-  const uint16_t _matchingPixelsMatrix[NROW][NCOL][2] = {
+  const uint8_t _matchingPixelsMatrix[NROW][NCOL][2] = {
     { { 21 , 22  }, { 19 , 20  }, { 17 , 18  }, { 15 , 16  }, { 13 , 14  }, { 11 , 12  }, { 9  , 10  }, { 7  , 8   }, { 5  , 6   }, { 3  , 4   }, { 1  , 2   } },
     { { 25 , 26  }, { 27 , 28  }, { 29 , 30  }, { 31 , 32  }, { 33 , 34  }, { 35 , 36  }, { 37 , 38  }, { 39 , 40  }, { 41 , 42  }, { 43 , 44  }, { 45 , 46  } },
     { { 69 , 70  }, { 67 , 68  }, { 65 , 66  }, { 63 , 64  }, { 61 , 62  }, { 59 , 60  }, { 57 , 58  }, { 55 , 56  }, { 53 , 54  }, { 51 , 52  }, { 49 , 50  } },
@@ -229,7 +265,7 @@ private:
     { { 213, 214 }, { 211, 212 }, { 209, 210 }, { 207, 208 }, { 205, 206 }, { 203, 204 }, { 201, 202 }, { 199, 200 }, { 197, 198 }, { 195, 196 }, { 193, 194 } },
     { { 217, 218 }, { 219, 220 }, { 221, 222 }, { 223, 224 }, { 225, 226 }, { 227, 228 }, { 229, 230 }, { 231, 232 }, { 233, 234 }, { 235, 236 }, { 237, 238 } }
   };
-  const uint16_t _matchingPixelsEdge[NEDGE][1] = { { 242 }, { 241 }, { 240 }, { 243 } };
+  const uint8_t _matchingPixelsEdge[NEDGE][1] = { { 242 }, { 241 }, { 240 }, { 243 } };
 
 public:
   virtual String getName()
@@ -252,7 +288,7 @@ public:
     return (NROW * 24) + NEDGE;
   }
 
-  const uint16_t *getLedsMatrixId(int row, int col)
+  const uint8_t *getLedsMatrixId(int row, int col)
   {
     if (row < 0) return NULL;
     if (col < 0) return NULL;
@@ -262,7 +298,7 @@ public:
     return _matchingPixelsMatrix[row][col];
   }
 
-  const uint16_t *getLedsEdgeId(int n)
+  const uint8_t *getLedsEdgeId(int n)
   {
     if (n < 0) return NULL;
     if (n > NEDGE - 1) return NULL;
@@ -271,68 +307,14 @@ public:
   }
 };
 
-class LedConfiguration100x100_3 : public LedConfiguration {
-private:
-  const uint16_t _matchingPixelsMatrix[NROW][NCOL][2] = {
-    { { 21 , 22  }, { 19 , 20  }, { 17 , 18  }, { 15 , 16  }, { 13 , 14  }, { 11 , 12  }, { 9  , 10  }, { 7  , 8   }, { 5  , 6   }, { 3  , 4   }, { 1  , 2   } },
-    { { 27 , 28  }, { 29 , 30  }, { 31 , 32  }, { 33 , 34  }, { 35 , 36  }, { 37 , 38  }, { 39 , 40  }, { 41 , 42  }, { 43 , 44  }, { 45 , 46  }, { 47 , 48  } },
-    { { 73 , 74  }, { 71 , 72  }, { 69 , 70  }, { 67 , 68  }, { 65 , 66  }, { 63 , 64  }, { 61 , 62  }, { 59 , 60  }, { 57 , 58  }, { 55 , 56  }, { 53 , 54  } },
-    { { 79 , 80  }, { 81 , 82  }, { 83 , 84  }, { 85 , 86  }, { 87 , 88  }, { 89 , 90  }, { 91 , 92  }, { 93 , 94  }, { 95 , 96  }, { 97 , 98  }, { 99 , 100 } },
-    { { 125, 126 }, { 123, 124 }, { 121, 122 }, { 119, 120 }, { 117, 118 }, { 115, 116 }, { 113, 114 }, { 111, 112 }, { 109, 110 }, { 107, 108 }, { 105, 106 } },
-    { { 131, 132 }, { 133, 134 }, { 135, 136 }, { 137, 138 }, { 139, 140 }, { 141, 142 }, { 143, 144 }, { 145, 146 }, { 147, 148 }, { 149, 150 }, { 151, 152 } },
-    { { 177, 178 }, { 175, 176 }, { 173, 174 }, { 171, 172 }, { 169, 170 }, { 167, 168 }, { 165, 166 }, { 163, 164 }, { 161, 162 }, { 159, 160 }, { 157, 158 } },
-    { { 183, 184 }, { 185, 186 }, { 187, 188 }, { 189, 190 }, { 191, 192 }, { 193, 194 }, { 195, 196 }, { 197, 198 }, { 199, 200 }, { 201, 202 }, { 203, 204 } },
-    { { 229, 230 }, { 227, 228 }, { 225, 226 }, { 223, 224 }, { 221, 222 }, { 219, 220 }, { 217, 218 }, { 215, 216 }, { 213, 214 }, { 211, 212 }, { 209, 210 } },
-    { { 235, 236 }, { 237, 238 }, { 239, 240 }, { 241, 242 }, { 243, 244 }, { 245, 246 }, { 247, 248 }, { 249, 250 }, { 251, 252 }, { 253, 254 }, { 255, 256 } },
-  };
-  const uint16_t _matchingPixelsEdge[NEDGE][1] = { { 260 }, { 259 }, { 258 }, { 261 } };
 
-public:
-  virtual String getName()
-  {
-    return "100x100@3";
-  }
-
-  int ledsByPixelForMatrix()
-  {
-    return 2;
-  }
-
-  int ledsByPixelForEdges()
-  {
-    return 1;
-  }
-
-  int ledsNumber()
-  {
-    return 262;
-  }
-
-  const uint16_t *getLedsMatrixId(int row, int col)
-  {
-    if (row < 0) return NULL;
-    if (col < 0) return NULL;
-    if (row > NROW - 1) return NULL;
-    if (col > NCOL - 1) return NULL;
-
-    return _matchingPixelsMatrix[row][col];
-  }
-
-  const uint16_t *getLedsEdgeId(int n)
-  {
-    if (n < 0) return NULL;
-    if (n > NEDGE - 1) return NULL;
-
-    return _matchingPixelsEdge[n];
-  }
-};
 
 //  0         x
 // 0+----------
 //  |
 //  |
 //  |
-// y|
+// y|  
 //
 void copyCharToMatrix(const uint8_t src[FONTROW][FONTCOL], PixelsArray &dst, int posx, int posy, const RgbColor &color)
 {
@@ -363,6 +345,7 @@ void copyNumberToMatrix(int n, PixelsArray &dst, const RgbColor &color)
   ::copyCharToMatrix(_font_number[abs(n % 10)], dst, x, 0 + 6, color); // Display "Second number"
 }
 
+
 enum RandomColorMode
 {
   ColorRandomNo = 0,
@@ -370,6 +353,7 @@ enum RandomColorMode
   ColorRandomLetter,
   ColorRandomWord
 };
+
 
 class LedStripMode
 {
@@ -391,7 +375,7 @@ protected:
     // Clear pixels
     setPixelsColor(pVOID);
   }
-
+  
 public:
   LedStripMode(String name, PixelsContainer *pPixelContainer)
     : _name(name)
@@ -420,6 +404,7 @@ public:
   {
     _colorRandomMode = c;
   }
+
 
   virtual void begin() = 0;
   virtual void handle() = 0;
@@ -450,6 +435,7 @@ public:
   {
     return true;
   }
+
 };
 
 #define LedStripModeTimeName "Time"
@@ -567,6 +553,7 @@ public:
   }
 };
 
+
 class LedStripModeSeconds : public LedStripMode
 {
 private:
@@ -642,6 +629,7 @@ public:
     return true;
   }
 };
+
 
 class LedStripModeTemperature : public LedStripMode
 {
@@ -793,6 +781,7 @@ public:
   }
 };
 
+
 class LedStripModeTestStrip : public LedStripMode
 {
 private:
@@ -842,6 +831,7 @@ public:
   }
 };
 
+
 class MyLedStrip
 {
 protected:
@@ -868,7 +858,7 @@ protected:
     for (int r = 0; r < NROW; r++) {
       for (int c = 0; c < NCOL; c++) {
         Pixel p = pPixel->pixelsArray.getPixel(r, c);
-        const uint16_t *i = _ledConfiguration[_ledConfigurationIndex]->getLedsMatrixId(r, c);
+        const uint8_t *i = _ledConfiguration[_ledConfigurationIndex]->getLedsMatrixId(r, c);
 
         if (!p.display) continue;
 
@@ -880,7 +870,7 @@ protected:
     // Fill leds strip with edge pixels
     for (int e = 0; e < NEDGE; e++) {
       Pixel p = pPixel->pixelsEdge[e];
-      const uint16_t *i = _ledConfiguration[_ledConfigurationIndex]->getLedsEdgeId(e);
+      const uint8_t *i = _ledConfiguration[_ledConfigurationIndex]->getLedsEdgeId(e);
 
       if (!p.display) continue;
 
@@ -910,7 +900,8 @@ protected:
     {
       int sd = _config.brightnessAutoMinDay;      // minimum brightness during the day
       int sn = _config.brightnessAutoMinNight;    // minimum brightness during the night
-      int sm = 255;                               // maximum brightness
+      //int sm = 255;                               // maximum brightness
+      int sm = _config.brightnessMax;         // maximum brightness auto
       int lmin = 0;                               // minimum lux sensitivity allowed
       int lmax = _config.luxSensitivity * 10;     // maximum lux sensitivity allowed
 
@@ -951,10 +942,10 @@ public:
     , _automaticBrightness(false)
     , _modeIndex(0)
   {
+
     _ledConfiguration.push_back(new LedConfiguration40x40());
     _ledConfiguration.push_back(new LedConfiguration100x100_1());
     _ledConfiguration.push_back(new LedConfiguration100x100_2());
-    _ledConfiguration.push_back(new LedConfiguration100x100_3());
 
     _modeList.push_back(new LedStripModeNothing(&_pixels));
     _modeList.push_back(new LedStripModeTime(&_pixels));
@@ -999,9 +990,9 @@ public:
     end();
 
     if (!_pStrip)
-    {
+    { 
       _ledConfigurationIndex = _config.ledConfig;
-
+      
       // Cannot use DMA because DMA GPIO is already used by serial/USB bridge :(
       _pStrip = new MyNeoPixelBrightnessBus(_ledConfiguration[_ledConfigurationIndex]->ledsNumber(), D4);
       _pStrip->Begin();
@@ -1128,6 +1119,9 @@ public:
   }
 };
 
+
+
+
 class LedStripAnimation
 {
 protected:
@@ -1245,7 +1239,7 @@ public:
 
   void begin()
   {
-    _frame.init(50);
+    _frame.init(50.0 * _config.animSpeed / 5.0);
 
     initPixelsList();
     clearPixelsColor();
@@ -1283,10 +1277,11 @@ private:
 
   RgbColor generateFireColor()
   {
-    RgbColor c = RgbColor(58, 58, 6);
-    c.Darken(random(15));
-    c.R += random(15);
-    return c;
+    uint8_t bMax = (uint8_t)((uint16_t)_config.animBrightnessMax * 255 / 100);
+    return RgbColor(
+      (uint8_t)((uint16_t)(200 + random(55)) * bMax / 255),
+      (uint8_t)((uint16_t)(30 + random(120)) * bMax / 255),
+      (uint8_t)((uint16_t)random(20) * bMax / 255));
   }
 
 public:
@@ -1297,7 +1292,7 @@ public:
 
   void begin()
   {
-    _frame.init(8);
+    _frame.init(8.0 * _config.animSpeed / 5.0);
   }
 
   void handle()
@@ -1336,21 +1331,22 @@ class LedStripAnimationMatrix : public LedStripAnimation
 private:
   Frame _frame;
   int _matrixColumn[NCOL];
-  int _matrixColumnSize;
+  int _matrixColumnSize[NCOL];
 
 public:
   LedStripAnimationMatrix(PixelsContainer *pPixelContainerInput, PixelsContainer *pPixelContainerOutput)
     : LedStripAnimation("Matrix", pPixelContainerInput, pPixelContainerOutput)
-    , _matrixColumnSize(9)
   {
   }
 
   void begin()
   {
-    _frame.init(8);
+    _frame.init(8.0 * _config.animSpeed / 10.0);
 
-    for (int i = 0; i < NCOL; i++)
+    for (int i = 0; i < NCOL; i++) {
       _matrixColumn[i] = -1;
+      _matrixColumnSize[i] = 0;
+    }
   }
 
   void handle()
@@ -1365,26 +1361,37 @@ public:
     // Create a new column if possible (= -1)
     for (int c = 0; c < NCOL; c++) {
       if (_matrixColumn[c] == -1) {
-        if (random(30) == 0) {
+        if (random(10) == 0) {
           _matrixColumn[c] = 0;
+          _matrixColumnSize[c] = 8 + random(12); // 8 à 19 pixels
         }
       }
     }
+
+    uint8_t bMax = (uint8_t)((uint16_t)_config.animBrightnessMax * 255 / 100);
 
     // Update display columns
     for (int c = 0; c < NCOL; c++) {
       if (_matrixColumn[c] == -1)
         continue;
 
-      Pixel green = pGREEN;
-      for (int r = _matrixColumn[c]; r > _matrixColumn[c] - _matrixColumnSize; r--) {
-        _pPixelContainerOutput->pixelsArray.setPixel(green, r, c);
-        green.color.Darken(30);
+      Pixel head = Pixel(RgbColor(
+        (uint8_t)((uint16_t)200 * bMax / 255), bMax,
+        (uint8_t)((uint16_t)200 * bMax / 255)));
+      Pixel trail = Pixel(RgbColor(0, bMax, 0));
+      for (int r = _matrixColumn[c]; r > _matrixColumn[c] - _matrixColumnSize[c]; r--) {
+        int dist = _matrixColumn[c] - r;
+        if (dist == 0) {
+          _pPixelContainerOutput->pixelsArray.setPixel(head, r, c);
+        } else {
+          _pPixelContainerOutput->pixelsArray.setPixel(trail, r, c);
+          if (dist >= 5) trail.color.Darken(35);
+        }
       }
 
       _matrixColumn[c]++;
 
-      if (_matrixColumn[c] > NROW + _matrixColumnSize)
+      if (_matrixColumn[c] > NROW + _matrixColumnSize[c])
         _matrixColumn[c] = -1;
     }
 
@@ -1423,7 +1430,7 @@ public:
 
   void begin()
   {
-    _frame.init(10);
+    _frame.init(10.0 * _config.animSpeed / 5.0);
   }
 
   void handle()
@@ -1433,7 +1440,7 @@ public:
 
     clearPixelsColor();
 
-    _rainbowIndex += 0.001;
+    _rainbowIndex += 0.004;
 
     if (_rainbowIndex > 1.0)
       _rainbowIndex = 0.0;
@@ -1441,7 +1448,8 @@ public:
     // Copy foreground matrix pixels
     for (int c = 0; c < NCOL; c++) {
       for (int r = 0; r < NROW; r++) {
-        double hsl = ((double)((r * NCOL) + c) / (double)(NROW * NCOL)) * (60.0 / 360.0);
+
+        double hsl = (double)((r * NCOL) + c) / (double)(NROW * NCOL);
         hsl += _rainbowIndex;
         if (hsl > 1.0) hsl -= 1.0;
 
@@ -1486,7 +1494,7 @@ public:
 
   void begin()
   {
-    _frame.init(4);
+    _frame.init(4.0 * _config.animSpeed / 5.0);
 
     for (int i = 0; i < NCOL; i++)
       _matrixColumn[i] = -1;
@@ -1515,7 +1523,8 @@ public:
       if (_matrixColumn[c] == -1)
         continue;
 
-      Pixel green = pWHITE;
+      uint8_t bMax = (uint8_t)((uint16_t)_config.animBrightnessMax * 255 / 100);
+      Pixel green = Pixel(RgbColor(bMax, bMax, bMax));
       for (int r = _matrixColumn[c]; r > _matrixColumn[c] - _matrixColumnSize; r--) {
         _pPixelContainerOutput->pixelsArray.setPixel(green, r, c);
         green.color.Darken(128);
@@ -1560,7 +1569,7 @@ public:
 
   void begin()
   {
-    _frame.init(5);
+    _frame.init(5.0 * _config.animSpeed / 5.0);
   }
 
   Pixel generateFire()
@@ -1582,9 +1591,13 @@ public:
 
     if (_dateTime.second / 10 % 2)
     {
-      Pixel white = Pixel(RgbColor(255, 255, 255));
-      Pixel red = Pixel(RgbColor(255, 0, 0));
-      Pixel brown = Pixel(RgbColor(125, 57, 0));
+      uint8_t bMax = (uint8_t)((uint16_t)_config.animBrightnessMax * 255 / 100);
+      Pixel white = Pixel(RgbColor(bMax, bMax, bMax));
+      Pixel red = Pixel(RgbColor(bMax, 0, 0));
+      Pixel brown = Pixel(RgbColor(
+        (uint8_t)((uint16_t)125 * bMax / 255),
+        (uint8_t)((uint16_t)57 * bMax / 255),
+        0));
 
       _pPixelContainerOutput->pixelsArray.setPixel(generateFire(), 2, 3);
       _pPixelContainerOutput->pixelsArray.setPixel(generateFire(), 2, 5);
@@ -1667,6 +1680,7 @@ public:
   }
 };
 
+
 class LedStripAnimationLove : public LedStripAnimation
 {
 private:
@@ -1680,7 +1694,7 @@ public:
 
   void begin()
   {
-    _frame.init(5);
+    _frame.init(5.0 * _config.animSpeed / 5.0);
   }
 
   void handle()
@@ -1693,8 +1707,12 @@ public:
     if (_dateTime.second / 10 % 2)
     {
       //Pixel white = Pixel(RgbColor(255, 255, 255));
-      Pixel red = Pixel(RgbColor(255, 0, 0));
-      Pixel pink = Pixel(RgbColor(0x69, 0x28, 0xDE));
+      uint8_t bMax = (uint8_t)((uint16_t)_config.animBrightnessMax * 255 / 100);
+      Pixel red = Pixel(RgbColor(bMax, 0, 0));
+      Pixel pink = Pixel(RgbColor(
+        (uint8_t)((uint16_t)0x69 * bMax / 255),
+        (uint8_t)((uint16_t)0x28 * bMax / 255),
+        (uint8_t)((uint16_t)0xDE * bMax / 255)));
 
       _pPixelContainerOutput->pixelsArray.setPixel(pink, 1, 2);
       _pPixelContainerOutput->pixelsArray.setPixel(pink, 1, 3);
@@ -1776,53 +1794,81 @@ public:
   }
 };
 
-class LedStripAnimationRipple : public LedStripAnimation
+class LedStripAnimationPulse : public LedStripAnimation
 {
 private:
-  struct Ripple {
-    int originR, originC;
-    int radius;
-    RgbColor baseColor;
-    bool active;
-  };
-
-  static const int MAX_RIPPLES = 2;
-  Ripple _ripples[MAX_RIPPLES];
   Frame _frame;
-
-  bool isInBounds(int r, int c)
-  {
-    return r >= 0 && r < NROW &&c >= 0 && c < NCOL;
-  }
-
-  void createNewRipple(int index)
-  {
-    _ripples[index].originR = random(NROW);
-    _ripples[index].originC = random(NCOL);
-    _ripples[index].radius = 0;
-    _ripples[index].baseColor = RgbColor(random(128, 255), random(64), random(255));
-    _ripples[index].active = true;
-  }
-
-  double euclideanDistance(int r1, int c1, int r2, int c2)
-  {
-    return sqrt((r1 - r2) * (r1 - r2) + (c1 - c2) * (c1 - c2));
-  }
+  uint16_t _phase;
 
 public:
-  LedStripAnimationRipple(PixelsContainer *pPixelContainerInput, PixelsContainer *pPixelContainerOutput)
-    : LedStripAnimation("Ripple", pPixelContainerInput, pPixelContainerOutput)
+  LedStripAnimationPulse(PixelsContainer *pPixelContainerInput, PixelsContainer *pPixelContainerOutput)
+    : LedStripAnimation("Pulse", pPixelContainerInput, pPixelContainerOutput)
+    , _phase(0)
   {
   }
 
   void begin()
   {
-    _frame.init(8);
-    for (int i = 0; i < MAX_RIPPLES; i++)
-      _ripples[i].active = false;
+    _frame.init(20.0 * _config.animSpeed / 5.0);
+    _phase = 0;
+  }
 
-    // Start the first wave
-    createNewRipple(0);
+  void handle()
+  {
+    if (!_frame.next())
+      return;
+
+    _phase = (_phase + 3) & 511;
+    uint8_t v = (_phase < 256) ? (uint8_t)_phase : (uint8_t)(511 - _phase);
+    uint8_t bMin = (uint8_t)((uint16_t)_config.animBrightnessMin * 255 / 100);
+    uint8_t bMax = (uint8_t)((uint16_t)_config.animBrightnessMax * 255 / 100);
+    uint8_t b = (bMax > bMin) ? (bMin + (uint8_t)((uint16_t)v * (bMax - bMin) / 255)) : bMin;
+
+    clearPixelsColor();
+
+    for (int c = 0; c < NCOL; c++) {
+      for (int r = 0; r < NROW; r++) {
+        Pixel pf = _pPixelContainerInput->pixelsArray.getPixel(r, c);
+        if (pf.display) {
+          pf.color = RgbColor(
+            (uint8_t)((uint16_t)pf.color.R * b / 255),
+            (uint8_t)((uint16_t)pf.color.G * b / 255),
+            (uint8_t)((uint16_t)pf.color.B * b / 255));
+          _pPixelContainerOutput->pixelsArray.setPixel(pf, r, c);
+        }
+      }
+    }
+    for (int e = 0; e < NEDGE; e++) {
+      Pixel pf = _pPixelContainerInput->pixelsEdge[e];
+      if (pf.display) {
+        pf.color = RgbColor(
+          (uint8_t)((uint16_t)pf.color.R * b / 255),
+          (uint8_t)((uint16_t)pf.color.G * b / 255),
+          (uint8_t)((uint16_t)pf.color.B * b / 255));
+        _pPixelContainerOutput->pixelsEdge[e] = pf;
+      }
+    }
+    _pPixelContainerOutput->hasChanged = true;
+  }
+};
+
+class LedStripAnimationSparkle : public LedStripAnimation
+{
+private:
+  Frame _frame;
+  uint8_t _sparks[NROW][NCOL];
+
+public:
+  LedStripAnimationSparkle(PixelsContainer *pPixelContainerInput, PixelsContainer *pPixelContainerOutput)
+    : LedStripAnimation("Sparkle", pPixelContainerInput, pPixelContainerOutput)
+  {
+    memset(_sparks, 0, sizeof(_sparks));
+  }
+
+  void begin()
+  {
+    _frame.init(15.0 * _config.animSpeed / 10.0);
+    memset(_sparks, 0, sizeof(_sparks));
   }
 
   void handle()
@@ -1832,48 +1878,147 @@ public:
 
     clearPixelsColor();
 
-    for (int r = 0; r < NROW; r++) {
-      for (int c = 0; c < NCOL; c++) {
-        Pixel p;
-        p.display = false;
-
-        for (int i = 0; i < MAX_RIPPLES; i++) {
-          if (!_ripples[i].active)
-            continue;
-
-          double dist = euclideanDistance(r, c, _ripples[i].originR, _ripples[i].originC);
-
-          if (abs(dist - _ripples[i].radius) < 0.5) {
-            RgbColor color = _ripples[i].baseColor;
-            int darkenAmount = (int)(dist * 10);
-            color.Darken(darkenAmount);
-
-            p.color = color;
+    for (int c = 0; c < NCOL; c++) {
+      for (int r = 0; r < NROW; r++) {
+        Pixel pf = _pPixelContainerInput->pixelsArray.getPixel(r, c);
+        if (pf.display) {
+          _sparks[r][c] = 0;
+          _pPixelContainerOutput->pixelsArray.setPixel(pf, r, c);
+        } else {
+          if (_sparks[r][c] > 40)
+            _sparks[r][c] -= 40;
+          else {
+            _sparks[r][c] = 0;
+            if (random(NROW * NCOL * 2) == 0)
+              _sparks[r][c] = 220;
+          }
+          if (_sparks[r][c] > 0) {
+            Pixel p;
+            p.color = RgbColor(
+              (uint8_t)((uint16_t)_sparks[r][c] * _config.animBrightnessMax / 100),
+              (uint8_t)((uint16_t)_sparks[r][c] * _config.animBrightnessMax / 100),
+              (uint8_t)((uint16_t)_sparks[r][c] * _config.animBrightnessMax / 100));
             p.display = true;
-            break;
+            _pPixelContainerOutput->pixelsArray.setPixel(p, r, c);
           }
         }
-
-        if (p.display)
-          _pPixelContainerOutput->pixelsArray.setPixel(p, r, c);
       }
     }
+    for (int e = 0; e < NEDGE; e++) {
+      Pixel pf = _pPixelContainerInput->pixelsEdge[e];
+      if (pf.display)
+        _pPixelContainerOutput->pixelsEdge[e] = pf;
+    }
+    _pPixelContainerOutput->hasChanged = true;
+  }
+};
 
-    for (int i = 0; i < MAX_RIPPLES; i++) {
-      if (_ripples[i].active) {
-        _ripples[i].radius++;
+class LedStripAnimationWave : public LedStripAnimation
+{
+private:
+  Frame _frame;
+  uint8_t _phase;
 
-        if (_ripples[i].radius > (NROW + NCOL) / 2) {
-          _ripples[i].active = false;
+public:
+  LedStripAnimationWave(PixelsContainer *pPixelContainerInput, PixelsContainer *pPixelContainerOutput)
+    : LedStripAnimation("Wave", pPixelContainerInput, pPixelContainerOutput)
+    , _phase(0)
+  {
+  }
+
+  void begin()
+  {
+    _frame.init(15.0 * _config.animSpeed / 5.0);
+    _phase = 0;
+  }
+
+  void handle()
+  {
+    if (!_frame.next())
+      return;
+
+    _phase += 2;
+
+    uint8_t bMin = (uint8_t)((uint16_t)_config.animBrightnessMin * 255 / 100);
+    uint8_t bMax = (uint8_t)((uint16_t)_config.animBrightnessMax * 255 / 100);
+    uint8_t bRange = (bMax > bMin) ? (bMax - bMin) : 0;
+
+    clearPixelsColor();
+
+    for (int c = 0; c < NCOL; c++) {
+      uint8_t colPhase = _phase + (uint8_t)(c * 255 / (NCOL - 1));
+      uint8_t tri = (colPhase < 128) ? (uint8_t)(colPhase << 1) : (uint8_t)((255 - colPhase) << 1);
+      uint8_t b = bMin + (uint8_t)((uint16_t)tri * bRange / 255);
+
+      for (int r = 0; r < NROW; r++) {
+        Pixel pf = _pPixelContainerInput->pixelsArray.getPixel(r, c);
+        if (pf.display) {
+          pf.color = RgbColor(
+            (uint8_t)((uint16_t)pf.color.R * b / 255),
+            (uint8_t)((uint16_t)pf.color.G * b / 255),
+            (uint8_t)((uint16_t)pf.color.B * b / 255));
+          _pPixelContainerOutput->pixelsArray.setPixel(pf, r, c);
         }
       }
-
-      if (!_ripples[i].active && random(100) < 10) {
-        createNewRipple(i);
+    }
+    for (int e = 0; e < NEDGE; e++) {
+      Pixel pf = _pPixelContainerInput->pixelsEdge[e];
+      if (pf.display) {
+        uint8_t ePhase = _phase + (uint8_t)(e * 64);
+        uint8_t tri = (ePhase < 128) ? (uint8_t)(ePhase << 1) : (uint8_t)((255 - ePhase) << 1);
+        uint8_t b = bMin + (uint8_t)((uint16_t)tri * bRange / 255);
+        pf.color = RgbColor(
+          (uint8_t)((uint16_t)pf.color.R * b / 255),
+          (uint8_t)((uint16_t)pf.color.G * b / 255),
+          (uint8_t)((uint16_t)pf.color.B * b / 255));
+        _pPixelContainerOutput->pixelsEdge[e] = pf;
       }
     }
+    _pPixelContainerOutput->hasChanged = true;
+  }
+};
 
-    // Copy foreground matrix pixels
+class LedStripAnimationLightning : public LedStripAnimation
+{
+protected:
+  Frame _frame;
+
+  enum Phase { PAUSE, BUILD, FLASH, FADE };
+  Phase _phase;
+
+  bool _boltGrid[NROW][NCOL];
+  int  _buildRow;
+  int  _flashTimer;
+  int  _pauseTimer;
+  int  _fadeProgress;
+
+  void generateBolt()
+  {
+    memset(_boltGrid, 0, sizeof(_boltGrid));
+    int8_t c = random(NCOL);
+    for (int r = 0; r < NROW; r++) {
+      _boltGrid[r][c] = true;
+      c = (int8_t)constrain(c + (int8_t)(random(3) - 1), 0, NCOL - 1);
+    }
+    int numBranches = random(3);
+    for (int b = 0; b < numBranches; b++) {
+      int startRow = 1 + random(NROW / 2);
+      int8_t bc = -1;
+      for (int col = 0; col < NCOL; col++) {
+        if (_boltGrid[startRow][col]) { bc = col; break; }
+      }
+      if (bc < 0) continue;
+      bc = (int8_t)constrain(bc + (int8_t)(random(3) - 1), 0, NCOL - 1);
+      for (int r = startRow + 1; r < NROW; r++) {
+        _boltGrid[r][bc] = true;
+        bc = (int8_t)constrain(bc + (int8_t)(random(3) - 1), 0, NCOL - 1);
+        if (random(3) == 0) break;
+      }
+    }
+  }
+
+  void copyForeground()
+  {
     for (int c = 0; c < NCOL; c++) {
       for (int r = 0; r < NROW; r++) {
         Pixel pf = _pPixelContainerInput->pixelsArray.getPixel(r, c);
@@ -1881,160 +2026,34 @@ public:
           _pPixelContainerOutput->pixelsArray.setPixel(pf, r, c);
       }
     }
-
-    // Copy foreground edge pixels
     for (int e = 0; e < NEDGE; e++) {
       Pixel pf = _pPixelContainerInput->pixelsEdge[e];
       if (pf.display)
         _pPixelContainerOutput->pixelsEdge[e] = pf;
     }
-
-    _pPixelContainerOutput->hasChanged = true;
-  }
-};
-
-class LedStripAnimationMinuteFall : public LedStripAnimation
-{
-private:
-  struct FallingPixel : PixelPos {
-    int ce;
-    int cc;
-    int cr;
-  };
-
-  Frame _frame;
-  int _lastMinute;
-  bool _animationInProgress;
-  int _animationPhase; // 0: falling old pixels, 1: rising new pixels
-
-  cl_Lst<PixelPos> _oldPixelPositions;
-  cl_Lst<FallingPixel> _fallingPixels;
-
-  void getPixelsList()
-  {
-    _oldPixelPositions.clear();
-
-    // Retrieve currently displayed pixels (old minute)
-    for (int c = 0; c < NCOL; c++) {
-      for (int r = 0; r < NROW; r++) {
-        Pixel p = _pPixelContainerInput->pixelsArray.getPixel(r, c);
-        if (p.display) {
-          PixelPos pp;
-          pp.e = -1;
-          pp.c = c;
-          pp.r = r;
-          pp.p = p;
-          _oldPixelPositions.push_back(pp);
-        }
-      }
-    }
-
-    // Retrieve edge pixels (old minute)
-    for (int e = 0; e < NEDGE; e++) {
-      Pixel p = _pPixelContainerInput->pixelsEdge[e];
-      if (p.display) {
-        PixelPos pp;
-        pp.e = e;
-        pp.c = -1;
-        pp.r = -1;
-        pp.p = p;
-        _oldPixelPositions.push_back(pp);
-      }
-    }
-  }
-
-  void startFallingAnimation()
-  {
-    // Clear falling pixels list
-    _fallingPixels.clear();
-
-    // Add all pixels that need to fall
-    for (int i = 0; i < _oldPixelPositions.size(); i++) {
-      FallingPixel fp;
-
-      fp.r = _oldPixelPositions[i].r;
-      fp.c = _oldPixelPositions[i].c;
-      fp.e = _oldPixelPositions[i].e;
-
-      fp.cr = -random(3, 20); // Random delay in frames
-      fp.cc = -random(3, 20); // Random delay in frames
-      fp.ce = -random(3, 20); // Random delay in frames
-
-      fp.p = _oldPixelPositions[i].p;
-
-      _fallingPixels.push_back(fp);
-    }
-
-    _animationPhase = 0;
-  }
-
-  void startRisingAnimation()
-  {
-    // Clear rising pixels list
-    _fallingPixels.clear();
-
-    // Create all rising pixels at once based on current input
-    for (int c = 0; c < NCOL; c++) {
-      for (int r = 0; r < NROW; r++) {
-        Pixel targetPixel = _pPixelContainerInput->pixelsArray.getPixel(r, c);
-        if (!targetPixel.display) continue;
-
-        FallingPixel fp;
-        fp.r = r;
-        fp.c = c;
-        fp.e = -1;
-        fp.cr = -random(3, 20); // Random delay in frames
-        fp.cc = -random(3, 20); // Random delay in frames
-        fp.ce = -random(3, 20); // Random delay in frames
-        fp.p = targetPixel;
-
-        _fallingPixels.push_back(fp);
-      }
-    }
-
-    // Handle edge pixels too
-    for (int e = 0; e < NEDGE; e++) {
-      Pixel targetPixel = _pPixelContainerInput->pixelsEdge[e];
-      if (!targetPixel.display) continue;
-
-      FallingPixel fp;
-      fp.r = -1;
-      fp.c = -1;
-      fp.e = e;
-      fp.cr = -random(3, 20); // Random delay in frames
-      fp.cc = -random(3, 20); // Random delay in frames
-      fp.ce = -random(3, 20); // Random delay in frames
-      fp.p = targetPixel;
-
-      _fallingPixels.push_back(fp);
-    }
-
-    _animationPhase = 1;
   }
 
 public:
-  LedStripAnimationMinuteFall(PixelsContainer *pPixelContainerInput, PixelsContainer *pPixelContainerOutput)
-    : LedStripAnimation("PixelsFalling", pPixelContainerInput, pPixelContainerOutput)
-    , _lastMinute(-1)
-    , _animationInProgress(false)
-    , _animationPhase(0)
+  LedStripAnimationLightning(PixelsContainer *pPixelContainerInput, PixelsContainer *pPixelContainerOutput)
+    : LedStripAnimation("Lightning", pPixelContainerInput, pPixelContainerOutput)
+    , _phase(PAUSE), _buildRow(0), _flashTimer(0), _pauseTimer(0), _fadeProgress(0)
   {
+    memset(_boltGrid, 0, sizeof(_boltGrid));
+  }
+
+  void setPauseTimer()
+  {
+    int r = random(10);
+    if (r < 2)      _pauseTimer = 3  + random(12);   // double-flash rapide
+    else if (r < 6) _pauseTimer = 40 + random(80);   // pause normale
+    else            _pauseTimer = 120 + random(200);  // longue attente
   }
 
   void begin()
   {
-    _frame.init(15); // Slow animation (fps)
-    _lastMinute = _dateTime.minute;
-    _animationInProgress = false;
-
-    // Clear falling pixels lists
-    _fallingPixels.clear();
-    //_risingPixels.clear();
-
-    // Force refresh of input pixels because
-    // we copy them to the output buffer only
-    // When they change. (To limit CPU usage)
-    _pPixelContainerInput->hasChanged = true;
+    _frame.init(30.0 * _config.animSpeed / 10.0);
+    _phase = PAUSE;
+    setPauseTimer();
   }
 
   void handle()
@@ -2042,109 +2061,89 @@ public:
     if (!_frame.next())
       return;
 
-    // Check if minute has changed
-    if (_dateTime.minute != _lastMinute && !_animationInProgress) {
-      _lastMinute = _dateTime.minute;
-      _animationInProgress = true;
-      startFallingAnimation();
-    }
-
-    getPixelsList();
-
-    if (!_animationInProgress) {
-      // No animation, just copy input to output
-      *_pPixelContainerOutput = *_pPixelContainerInput;
-      _pPixelContainerOutput->hasChanged = true;
-      return;
-    }
-
     clearPixelsColor();
+    uint8_t bMax = (uint8_t)((uint16_t)_config.animBrightnessMax * 255 / 100);
 
-    if (_animationPhase == 0) {
-      bool allFallen = true;
+    switch (_phase)
+    {
+      case PAUSE:
+        copyForeground();
+        if (--_pauseTimer <= 0) {
+          generateBolt();
+          _buildRow = 0;
+          _phase = BUILD;
+        }
+        break;
 
-      for (int i = 0; i < _fallingPixels.size(); i++) {
-        _fallingPixels[i].cr++;
-
-        // Matrix pixel
-        if (_fallingPixels[i].e == -1) {
-          // If the pixel current position is under the matrix, do nothing (no display)
-          if (_fallingPixels[i].cr > NROW) continue;
-
-          // If the pixel current position is above the original position, display at original position (delay phase)
-          else if (_fallingPixels[i].cr < _fallingPixels[i].r) {
-            _pPixelContainerOutput->pixelsArray.setPixel(_fallingPixels[i].p, _fallingPixels[i].r, _fallingPixels[i].c);
-            allFallen = false;
-          }
-
-          // If the pixel current position is below the original position, display at current position (falling)
-          else {
-            _pPixelContainerOutput->pixelsArray.setPixel(_fallingPixels[i].p, _fallingPixels[i].cr, _fallingPixels[i].c);
-            allFallen = false;
+      case BUILD:
+        _buildRow = min(_buildRow + 2, NROW);
+        for (int r = 0; r < _buildRow; r++) {
+          for (int col = 0; col < NCOL; col++) {
+            if (_boltGrid[r][col]) {
+              Pixel p;
+              p.color = RgbColor(bMax, bMax, bMax);
+              p.display = true;
+              _pPixelContainerOutput->pixelsArray.setPixel(p, r, col);
+            }
           }
         }
+        copyForeground();
+        if (_buildRow >= NROW) {
+          _flashTimer = 3;
+          _phase = FLASH;
+        }
+        break;
 
-        // Edge pixel
-        if (_fallingPixels[i].c == -1 && _fallingPixels[i].r == -1) {
-          // If pixel current position is in delay phase, display it at edge position
-          if (_fallingPixels[i].cr < 0) {
-            _pPixelContainerOutput->pixelsEdge[_fallingPixels[i].e] = _fallingPixels[i].p;
-            allFallen = false;
+      case FLASH:
+      {
+        uint8_t fb = bMax / 2;
+        for (int r = 0; r < NROW; r++) {
+          for (int col = 0; col < NCOL; col++) {
+            Pixel p;
+            p.color = RgbColor(fb, fb, fb);
+            p.display = true;
+            _pPixelContainerOutput->pixelsArray.setPixel(p, r, col);
           }
         }
-      }
-
-      if (allFallen) {
-        // All pixels have fallen, switch to rising phase
-        startRisingAnimation();
-      }
-    }
-
-    if (_animationPhase == 1) {
-      // Second step: rising pixels of new time
-      bool allRisen = true;
-
-      // Animate all rising pixels
-      for (int i = 0; i < _fallingPixels.size(); i++) {
-        _fallingPixels[i].cr++;
-
-        // Matrix pixel
-        if (_fallingPixels[i].e == -1) {
-          // If the pixel current position is in delay phase (above matrix), wait
-          if (_fallingPixels[i].cr < 0) {
-            allRisen = false;
-            continue;
-          }
-
-          // If the pixel current position is falling to destination
-          else if (_fallingPixels[i].cr <= _fallingPixels[i].r) {
-            _pPixelContainerOutput->pixelsArray.setPixel(_fallingPixels[i].p, _fallingPixels[i].cr, _fallingPixels[i].c);
-            allRisen = false;
-          }
-
-          // If the pixel current position has reached its destination
-          else {
-            _pPixelContainerOutput->pixelsArray.setPixel(_fallingPixels[i].p, _fallingPixels[i].r, _fallingPixels[i].c);
-          }
-        }
-
-        // Edge pixel
-        if (_fallingPixels[i].c == -1 && _fallingPixels[i].r == -1) {
-          // If pixel current position is in delay phase, wait
-          if (_fallingPixels[i].cr < 0) {
-            allRisen = false;
-          }
-
-          // Display pixel at edge position (reached destination)
-          else {
-            _pPixelContainerOutput->pixelsEdge[_fallingPixels[i].e] = _fallingPixels[i].p;
-          }
+        for (int e = 0; e < NEDGE; e++) {
+          Pixel p;
+          p.color = RgbColor(fb, fb, fb);
+          p.display = true;
+          _pPixelContainerOutput->pixelsEdge[e] = p;
         }
       }
+        if (--_flashTimer <= 0) {
+          _fadeProgress = 0;
+          _phase = FADE;
+        }
+        break;
 
-      if (allRisen) {
-        // Animation complete
-        _animationInProgress = false;
+      case FADE:
+      {
+        bool anyVisible = false;
+        for (int r = 0; r < NROW; r++) {
+          int bright = 255 - max(0, _fadeProgress - r) * 20;
+          if (bright < 0) bright = 0;
+          if (bright > 0) {
+            anyVisible = true;
+            uint8_t b = (uint8_t)((uint16_t)bright * bMax / 255);
+            for (int col = 0; col < NCOL; col++) {
+              if (_boltGrid[r][col]) {
+                Pixel p;
+                p.color = RgbColor(b, b, b);
+                p.display = true;
+                _pPixelContainerOutput->pixelsArray.setPixel(p, r, col);
+              }
+            }
+          }
+        }
+        copyForeground();
+        _fadeProgress++;
+        if (!anyVisible) {
+          _phase = PAUSE;
+          setPauseTimer();
+        }
+        break;
       }
     }
 
@@ -2152,27 +2151,490 @@ public:
   }
 };
 
+class LedStripAnimationStorm : public LedStripAnimationLightning
+{
+public:
+  LedStripAnimationStorm(PixelsContainer *pPixelContainerInput, PixelsContainer *pPixelContainerOutput)
+    : LedStripAnimationLightning(pPixelContainerInput, pPixelContainerOutput)
+  {
+    _name = "Storm";
+  }
+
+  void handle()
+  {
+    if (!_frame.next())
+      return;
+
+    clearPixelsColor();
+    uint8_t bMax = (uint8_t)((uint16_t)_config.animBrightnessMax * 255 / 100);
+
+    switch (_phase)
+    {
+      case PAUSE:
+        copyForeground();
+        if (--_pauseTimer <= 0) {
+          generateBolt();
+          _buildRow = 0;
+          _phase = BUILD;
+        }
+        break;
+
+      case BUILD:
+        _buildRow = min(_buildRow + 2, NROW);
+        for (int r = 0; r < _buildRow; r++) {
+          for (int col = 0; col < NCOL; col++) {
+            if (_boltGrid[r][col]) {
+              Pixel p;
+              p.color = RgbColor(bMax, bMax, bMax);
+              p.display = true;
+              _pPixelContainerOutput->pixelsArray.setPixel(p, r, col);
+            }
+          }
+        }
+        copyForeground();
+        if (_buildRow >= NROW) {
+          _fadeProgress = 0;
+          _phase = FADE;
+        }
+        break;
+
+      case FLASH:
+        break;
+
+      case FADE:
+      {
+        bool anyVisible = false;
+        for (int r = 0; r < NROW; r++) {
+          int bright = 255 - max(0, _fadeProgress - r) * 20;
+          if (bright < 0) bright = 0;
+          if (bright > 0) {
+            anyVisible = true;
+            uint8_t b = (uint8_t)((uint16_t)bright * bMax / 255);
+            for (int col = 0; col < NCOL; col++) {
+              if (_boltGrid[r][col]) {
+                Pixel p;
+                p.color = RgbColor(b, b, b);
+                p.display = true;
+                _pPixelContainerOutput->pixelsArray.setPixel(p, r, col);
+              }
+            }
+          }
+        }
+        copyForeground();
+        _fadeProgress++;
+        if (!anyVisible) {
+          _phase = PAUSE;
+          setPauseTimer();
+        }
+        break;
+      }
+    }
+
+    _pPixelContainerOutput->hasChanged = true;
+  }
+};
+
+// ---- Tetris ----
+
+static const int8_t TET_PIECES[7][4][4][2] = {
+  // I
+  {{{0,0},{0,1},{0,2},{0,3}}, {{0,2},{1,2},{2,2},{3,2}}, {{0,0},{0,1},{0,2},{0,3}}, {{0,1},{1,1},{2,1},{3,1}}},
+  // O
+  {{{0,1},{0,2},{1,1},{1,2}}, {{0,1},{0,2},{1,1},{1,2}}, {{0,1},{0,2},{1,1},{1,2}}, {{0,1},{0,2},{1,1},{1,2}}},
+  // T
+  {{{0,1},{1,0},{1,1},{1,2}}, {{0,1},{1,1},{1,2},{2,1}}, {{1,0},{1,1},{1,2},{2,1}}, {{0,1},{1,0},{1,1},{2,1}}},
+  // S
+  {{{0,1},{0,2},{1,0},{1,1}}, {{0,1},{1,1},{1,2},{2,2}}, {{0,1},{0,2},{1,0},{1,1}}, {{0,1},{1,1},{1,2},{2,2}}},
+  // Z
+  {{{0,0},{0,1},{1,1},{1,2}}, {{0,2},{1,1},{1,2},{2,1}}, {{0,0},{0,1},{1,1},{1,2}}, {{0,2},{1,1},{1,2},{2,1}}},
+  // J
+  {{{0,0},{1,0},{1,1},{1,2}}, {{0,1},{0,2},{1,1},{2,1}}, {{1,0},{1,1},{1,2},{2,2}}, {{0,1},{1,1},{2,0},{2,1}}},
+  // L
+  {{{0,2},{1,0},{1,1},{1,2}}, {{0,1},{1,1},{2,1},{2,2}}, {{1,0},{1,1},{1,2},{2,0}}, {{0,0},{0,1},{1,1},{2,1}}}
+};
+
+static const RgbColor TET_COLORS[7] = {
+  RgbColor(  0, 200, 200),  // I cyan
+  RgbColor(200, 200,   0),  // O yellow
+  RgbColor(150,   0, 200),  // T purple
+  RgbColor(  0, 200,   0),  // S green
+  RgbColor(200,   0,   0),  // Z red
+  RgbColor(  0,   0, 200),  // J blue
+  RgbColor(200, 100,   0),  // L orange
+};
+
+class LedStripAnimationTetris : public LedStripAnimation
+{
+public:
+  static LedStripAnimationTetris *instance;
+
+  enum TetAction { ACT_NONE=0, ACT_LEFT, ACT_RIGHT, ACT_ROTATE, ACT_DOWN, ACT_DROP, ACT_START };
+  enum TetState  { STATE_IDLE, STATE_PLAYING, STATE_GAME_OVER };
+
+private:
+  Frame    _frame;
+  uint8_t  _board[NROW][NCOL];
+  int8_t   _pieceType, _pieceRot, _pieceRow, _pieceCol, _nextPiece;
+  uint32_t _lastTick, _tickInterval;
+  uint16_t _score;
+  uint8_t  _lines, _level;
+  TetState  _state;
+  TetAction _pendingAction;
+
+  void getCells(int8_t type, int8_t rot, int8_t row, int8_t col, int8_t out[4][2])
+  {
+    for (int i = 0; i < 4; i++) {
+      out[i][0] = row + TET_PIECES[type][rot][i][0];
+      out[i][1] = col + TET_PIECES[type][rot][i][1];
+    }
+  }
+
+  bool canPlace(int8_t type, int8_t rot, int8_t row, int8_t col)
+  {
+    int8_t cells[4][2];
+    getCells(type, rot, row, col, cells);
+    for (int i = 0; i < 4; i++) {
+      int8_t r = cells[i][0], c = cells[i][1];
+      if (r < 0 || r >= NROW || c < 0 || c >= NCOL) return false;
+      if (_board[r][c]) return false;
+    }
+    return true;
+  }
+
+  void clearLines()
+  {
+    uint8_t cleared = 0;
+    for (int r = NROW - 1; r >= 0; r--) {
+      bool full = true;
+      for (int c = 0; c < NCOL; c++) if (!_board[r][c]) { full = false; break; }
+      if (full) {
+        for (int rr = r; rr > 0; rr--) memcpy(_board[rr], _board[rr-1], NCOL);
+        memset(_board[0], 0, NCOL);
+        cleared++; r++;
+      }
+    }
+    if (cleared) {
+      const uint16_t pts[4] = {100, 300, 500, 800};
+      _score += pts[min((int)cleared - 1, 3)] * (_level + 1);
+      _lines += cleared;
+      _level  = _lines / 10;
+      _tickInterval = max(100UL, 800UL - (uint32_t)_level * 70UL);
+    }
+  }
+
+  void spawnPiece(int8_t type)
+  {
+    _pieceType = type;
+    _pieceRot  = 0;
+    _pieceRow  = 0;
+    _pieceCol  = NCOL / 2 - 2;
+    if (!canPlace(_pieceType, _pieceRot, _pieceRow, _pieceCol))
+      _state = STATE_GAME_OVER;
+  }
+
+  void lockPiece()
+  {
+    int8_t cells[4][2];
+    getCells(_pieceType, _pieceRot, _pieceRow, _pieceCol, cells);
+    for (int i = 0; i < 4; i++) {
+      int8_t r = cells[i][0], c = cells[i][1];
+      if (r >= 0 && r < NROW && c >= 0 && c < NCOL)
+        _board[r][c] = _pieceType + 1;
+    }
+    clearLines();
+    spawnPiece(_nextPiece);
+    _nextPiece = random(7);
+  }
+
+  void startGame()
+  {
+    memset(_board, 0, sizeof(_board));
+    _score = 0; _lines = 0; _level = 0; _tickInterval = 800;
+    _nextPiece = random(7);
+    _lastTick  = millis();
+    _state     = STATE_PLAYING;
+    spawnPiece(random(7));
+  }
+
+  void renderBoard()
+  {
+    clearPixelsColor();
+    uint8_t bMax = (uint8_t)((uint16_t)_config.animBrightnessMax * 255 / 100);
+
+    for (int r = 0; r < NROW; r++) {
+      for (int c = 0; c < NCOL; c++) {
+        if (_board[r][c]) {
+          RgbColor col = TET_COLORS[_board[r][c] - 1];
+          Pixel p;
+          p.color = RgbColor(
+            (uint8_t)((uint16_t)col.R * bMax / 512),
+            (uint8_t)((uint16_t)col.G * bMax / 512),
+            (uint8_t)((uint16_t)col.B * bMax / 512));
+          p.display = true;
+          _pPixelContainerOutput->pixelsArray.setPixel(p, r, c);
+        } else if (_state == STATE_GAME_OVER && (millis() / 300) % 2 == 0) {
+          Pixel p; p.display = true;
+          p.color = RgbColor((uint8_t)((uint16_t)200 * bMax / 255), 0, 0);
+          _pPixelContainerOutput->pixelsArray.setPixel(p, r, c);
+        }
+      }
+    }
+
+    if (_state == STATE_PLAYING) {
+      int8_t cells[4][2];
+      getCells(_pieceType, _pieceRot, _pieceRow, _pieceCol, cells);
+      for (int i = 0; i < 4; i++) {
+        int8_t r = cells[i][0], c = cells[i][1];
+        if (r >= 0 && r < NROW && c >= 0 && c < NCOL) {
+          RgbColor col = TET_COLORS[_pieceType];
+          Pixel p;
+          p.color = RgbColor(
+            (uint8_t)((uint16_t)col.R * bMax / 255),
+            (uint8_t)((uint16_t)col.G * bMax / 255),
+            (uint8_t)((uint16_t)col.B * bMax / 255));
+          p.display = true;
+          _pPixelContainerOutput->pixelsArray.setPixel(p, r, c);
+        }
+      }
+    }
+
+    _pPixelContainerOutput->hasChanged = true;
+  }
+
+public:
+  LedStripAnimationTetris(PixelsContainer *in, PixelsContainer *out)
+    : LedStripAnimation("Tetris", in, out)
+    , _pieceType(0), _pieceRot(0), _pieceRow(0), _pieceCol(0), _nextPiece(0)
+    , _lastTick(0), _tickInterval(800)
+    , _score(0), _lines(0), _level(0)
+    , _state(STATE_IDLE), _pendingAction(ACT_NONE)
+  {
+    memset(_board, 0, sizeof(_board));
+    instance = this;
+  }
+
+  void begin()
+  {
+    _frame.init(30.0);
+    startGame();
+  }
+
+  void action(TetAction act) { _pendingAction = act; }
+  TetState getState()        { return _state; }
+  uint16_t getScore()        { return _score; }
+  uint8_t  getLines()        { return _lines; }
+  uint8_t  getLevel()        { return _level; }
+  int8_t   getNext()         { return _nextPiece; }
+
+  void handle()
+  {
+    TetAction act = _pendingAction;
+    _pendingAction = ACT_NONE;
+
+    if (_state == STATE_GAME_OVER) {
+      if (act == ACT_START) startGame();
+    } else if (_state == STATE_PLAYING) {
+      if      (act == ACT_LEFT   && canPlace(_pieceType, _pieceRot, _pieceRow, _pieceCol-1)) _pieceCol--;
+      else if (act == ACT_RIGHT  && canPlace(_pieceType, _pieceRot, _pieceRow, _pieceCol+1)) _pieceCol++;
+      else if (act == ACT_ROTATE) {
+        int8_t nr = (_pieceRot + 1) % 4;
+        if (canPlace(_pieceType, nr, _pieceRow, _pieceCol)) _pieceRot = nr;
+      }
+      else if (act == ACT_DOWN) {
+        if (canPlace(_pieceType, _pieceRot, _pieceRow+1, _pieceCol)) _pieceRow++;
+        else lockPiece();
+        _lastTick = millis();
+      }
+      else if (act == ACT_DROP) {
+        while (canPlace(_pieceType, _pieceRot, _pieceRow+1, _pieceCol)) _pieceRow++;
+        lockPiece();
+        _lastTick = millis();
+      }
+
+      uint32_t now = millis();
+      if (now - _lastTick >= _tickInterval) {
+        _lastTick = now;
+        if (canPlace(_pieceType, _pieceRot, _pieceRow+1, _pieceCol)) _pieceRow++;
+        else lockPiece();
+      }
+    }
+
+    if (_frame.next()) renderBoard();
+  }
+};
+
+LedStripAnimationTetris* LedStripAnimationTetris::instance = nullptr;
+
+class LedStripAnimationSnake : public LedStripAnimation
+{
+public:
+  static LedStripAnimationSnake *instance;
+
+  enum SnaAction { ACT_NONE=0, ACT_UP, ACT_DOWN, ACT_LEFT, ACT_RIGHT, ACT_START };
+  enum SnaState  { STATE_IDLE, STATE_PLAYING, STATE_GAME_OVER };
+  struct Pos { int8_t x, y; };
+
+private:
+  Frame    _frame;
+  Pos      _body[NROW * NCOL];
+  int      _length;
+  int8_t   _dirX, _dirY;
+  int8_t   _nextDirX, _nextDirY;
+  Pos      _food;
+  uint16_t _score;
+  SnaState  _state;
+  uint32_t _lastTick;
+  uint32_t _tickInterval;
+  SnaAction _pendingAction;
+
+  void spawnFood()
+  {
+    Pos free[NROW * NCOL];
+    int nFree = 0;
+    for (int r = 0; r < NROW; r++) {
+      for (int c = 0; c < NCOL; c++) {
+        bool occ = false;
+        for (int i = 0; i < _length; i++)
+          if (_body[i].y == r && _body[i].x == c) { occ = true; break; }
+        if (!occ) free[nFree++] = {(int8_t)c, (int8_t)r};
+      }
+    }
+    if (nFree > 0) _food = free[random(nFree)];
+  }
+
+  void startGame()
+  {
+    _length = 3;
+    _body[0] = {5, 5}; _body[1] = {4, 5}; _body[2] = {3, 5};
+    _dirX = 1; _dirY = 0; _nextDirX = 1; _nextDirY = 0;
+    _score = 0; _tickInterval = 350; _lastTick = millis();
+    _state = STATE_PLAYING;
+    spawnFood();
+  }
+
+  void tick()
+  {
+    _dirX = _nextDirX; _dirY = _nextDirY;
+    int8_t nx = _body[0].x + _dirX;
+    int8_t ny = _body[0].y + _dirY;
+
+    if (nx < 0 || nx >= NCOL || ny < 0 || ny >= NROW) { _state = STATE_GAME_OVER; return; }
+    for (int i = 0; i < _length - 1; i++)
+      if (_body[i].x == nx && _body[i].y == ny) { _state = STATE_GAME_OVER; return; }
+
+    bool ate = (nx == _food.x && ny == _food.y);
+    int newLen = ate ? min(_length + 1, NROW * NCOL) : _length;
+    for (int i = newLen - 1; i > 0; i--) _body[i] = _body[i-1];
+    _body[0] = {nx, ny};
+    _length = newLen;
+    if (ate) {
+      _score += 10;
+      if (_tickInterval > 100) _tickInterval -= 5;
+      spawnFood();
+    }
+  }
+
+  void renderBoard()
+  {
+    clearPixelsColor();
+    uint8_t bMax = (uint8_t)((uint16_t)_config.animBrightnessMax * 255 / 100);
+
+    bool blink = (millis() / 300) % 2 == 0;
+
+    if (_state == STATE_GAME_OVER && blink) {
+      bool occ[NROW][NCOL] = {};
+      for (int i = 0; i < _length; i++) occ[_body[i].y][_body[i].x] = true;
+      Pixel p; p.display = true;
+      p.color = RgbColor((uint8_t)((uint16_t)200 * bMax / 255), 0, 0);
+      for (int r = 0; r < NROW; r++)
+        for (int c = 0; c < NCOL; c++)
+          if (!occ[r][c]) _pPixelContainerOutput->pixelsArray.setPixel(p, r, c);
+    } else if (_state == STATE_PLAYING && blink) {
+      Pixel p; p.display = true;
+      p.color = RgbColor((uint8_t)((uint16_t)255 * bMax / 255), (uint8_t)((uint16_t)80 * bMax / 255), 0);
+      _pPixelContainerOutput->pixelsArray.setPixel(p, _food.y, _food.x);
+    }
+
+    for (int i = _length - 1; i >= 0; i--) {
+      uint8_t g = (i == 0) ? 255 : (uint8_t)max(60, 220 - i * 8);
+      uint8_t b = (i == 0) ? 80  : 0;
+      Pixel p; p.display = true;
+      p.color = RgbColor(0, (uint8_t)((uint16_t)g * bMax / 255), (uint8_t)((uint16_t)b * bMax / 255));
+      _pPixelContainerOutput->pixelsArray.setPixel(p, _body[i].y, _body[i].x);
+    }
+    _pPixelContainerOutput->hasChanged = true;
+  }
+
+public:
+  LedStripAnimationSnake(PixelsContainer *in, PixelsContainer *out)
+    : LedStripAnimation("Snake", in, out)
+    , _length(0), _dirX(1), _dirY(0), _nextDirX(1), _nextDirY(0)
+    , _score(0), _tickInterval(350), _lastTick(0)
+    , _state(STATE_IDLE), _pendingAction(ACT_NONE)
+  { instance = this; }
+
+  void begin() { _frame.init(30.0); startGame(); }
+  void action(SnaAction act) { _pendingAction = act; }
+  SnaState getState() { return _state; }
+  uint16_t getScore() { return _score; }
+
+  void handle()
+  {
+    SnaAction act = _pendingAction;
+    _pendingAction = ACT_NONE;
+
+    if (_state == STATE_GAME_OVER) {
+      if (act == ACT_START) startGame();
+    } else if (_state == STATE_PLAYING) {
+      switch (act) {
+        case ACT_UP:    if (_dirY == 0) { _nextDirX=0;  _nextDirY=-1; } break;
+        case ACT_DOWN:  if (_dirY == 0) { _nextDirX=0;  _nextDirY=1;  } break;
+        case ACT_LEFT:  if (_dirX == 0) { _nextDirX=-1; _nextDirY=0;  } break;
+        case ACT_RIGHT: if (_dirX == 0) { _nextDirX=1;  _nextDirY=0;  } break;
+        default: break;
+      }
+      uint32_t now = millis();
+      if (now - _lastTick >= _tickInterval) { _lastTick = now; tick(); }
+    }
+    if (_frame.next()) renderBoard();
+  }
+};
+
+LedStripAnimationSnake* LedStripAnimationSnake::instance = nullptr;
+
 class MyLedStripAnimator : public MyLedStrip
 {
 protected:
   PixelsContainer _animatedPixels;
   cl_Lst<LedStripAnimation *> _animationList;
   int _animationIndex;
+  LedStripAnimationTetris *_tetrisAnim;
+  bool _tetrisActive;
+  LedStripAnimationSnake *_snakeAnim;
+  bool _snakeActive;
+  int  _savedAnimIndex;
 
   bool handleAnimation()
   {
+    if (_tetrisActive) {
+      if (_animatedPixels.hasChanged) return false;
+      _tetrisAnim->handle();
+      if (_animatedPixels.hasChanged) _pixels.hasChanged = false;
+      return true;
+    }
+    if (_snakeActive) {
+      if (_animatedPixels.hasChanged) return false;
+      _snakeAnim->handle();
+      if (_animatedPixels.hasChanged) _pixels.hasChanged = false;
+      return true;
+    }
+
     if (_animationIndex < 0) return false;
     if (_animationIndex > _animationList.size() - 1) return false;
-
-    // check if the animated pixel buffer is displayed
-    // if not, do not update the animated pixel buffer
     if (_animatedPixels.hasChanged) return false;
 
-    // update the animated pixel buffer
     _animationList[_animationIndex]->handle();
 
-    // if output pixels buffer is updated
-    // then simulate update of the input buffer
     if (_animatedPixels.hasChanged)
       _pixels.hasChanged = false;
 
@@ -2183,6 +2645,9 @@ public:
   MyLedStripAnimator()
     : MyLedStrip()
     , _animationIndex(0)
+    , _tetrisActive(false)
+    , _snakeActive(false)
+    , _savedAnimIndex(0)
   {
     _animationList.push_back(new LedStripAnimationNormal(&_pixels, &_animatedPixels));
     _animationList.push_back(new LedStripAnimationBlink(&_pixels, &_animatedPixels));
@@ -2192,9 +2657,50 @@ public:
     _animationList.push_back(new LedStripAnimationSnowFlake(&_pixels, &_animatedPixels));
     _animationList.push_back(new LedStripAnimationCake(&_pixels, &_animatedPixels));
     _animationList.push_back(new LedStripAnimationLove(&_pixels, &_animatedPixels));
-    _animationList.push_back(new LedStripAnimationRipple(&_pixels, &_animatedPixels));
-    _animationList.push_back(new LedStripAnimationMinuteFall(&_pixels, &_animatedPixels));
+    _animationList.push_back(new LedStripAnimationPulse(&_pixels, &_animatedPixels));
+    _animationList.push_back(new LedStripAnimationSparkle(&_pixels, &_animatedPixels));
+    _animationList.push_back(new LedStripAnimationWave(&_pixels, &_animatedPixels));
+    _animationList.push_back(new LedStripAnimationLightning(&_pixels, &_animatedPixels));
+    _animationList.push_back(new LedStripAnimationStorm(&_pixels, &_animatedPixels));
+    _tetrisAnim = new LedStripAnimationTetris(&_pixels, &_animatedPixels);
+    _snakeAnim  = new LedStripAnimationSnake(&_pixels, &_animatedPixels);
   }
+
+  void tetrisStart()
+  {
+    _savedAnimIndex = _animationIndex;
+    _tetrisActive   = true;
+    _tetrisAnim->begin();
+  }
+
+  void tetrisStop()
+  {
+    _tetrisActive  = false;
+    _animationIndex = _savedAnimIndex;
+    if (_animationIndex >= 0 && _animationIndex < _animationList.size())
+      _animationList[_animationIndex]->begin();
+    _pixels.hasChanged = true;
+  }
+
+  bool isTetrisActive() { return _tetrisActive; }
+
+  void snakeStart()
+  {
+    _savedAnimIndex = _animationIndex;
+    _snakeActive    = true;
+    _snakeAnim->begin();
+  }
+
+  void snakeStop()
+  {
+    _snakeActive    = false;
+    _animationIndex = _savedAnimIndex;
+    if (_animationIndex >= 0 && _animationIndex < _animationList.size())
+      _animationList[_animationIndex]->begin();
+    _pixels.hasChanged = true;
+  }
+
+  bool isSnakeActive() { return _snakeActive; }
 
   bool setAnimation(int mode)
   {
@@ -2207,6 +2713,13 @@ public:
     _mqtt.publish(mqttTopicPubLedAnim.topic().c_str(), String(mode).c_str());
 
     return true;
+  }
+
+  void setAnimSpeed(byte speed)
+  {
+    _config.animSpeed = max((byte)1, min((byte)20, speed));
+    if (_animationIndex >= 0 && _animationIndex < _animationList.size())
+      _animationList[_animationIndex]->begin();
   }
 
   int getAnimationIndex()

--- a/NTP.h
+++ b/NTP.h
@@ -183,7 +183,7 @@ boolean summerTime(unsigned long timeStamp) {
 }
 
 unsigned long adjustTimeZone(unsigned long timeStamp, int timeZone, bool isDayLightSavingSaving) {
-  timeStamp += (long)timeZone * 3600; // adjust timezone (unit = 1/10th hour → seconds)
+  timeStamp += (long)timeZone * 360; // adjust timezone (unit = 1/10th hour, e.g. GMT+1 = value 10)
   if (isDayLightSavingSaving && summerTime(timeStamp)) timeStamp += 3600; // Sommerzeit beachten
   return timeStamp;
 }

--- a/NTP.h
+++ b/NTP.h
@@ -183,7 +183,7 @@ boolean summerTime(unsigned long timeStamp) {
 }
 
 unsigned long adjustTimeZone(unsigned long timeStamp, int timeZone, bool isDayLightSavingSaving) {
-  timeStamp += timeZone * 360; // adjust timezone
+  timeStamp += (long)timeZone * 3600; // adjust timezone (unit = 1/10th hour → seconds)
   if (isDayLightSavingSaving && summerTime(timeStamp)) timeStamp += 3600; // Sommerzeit beachten
   return timeStamp;
 }

--- a/Page_general.h
+++ b/Page_general.h
@@ -73,6 +73,9 @@ void send_general_configuration_values_html()
   values += "colorrandom|" + (String)_config.colorRandom + "|input\n";
   values += "ledconfig|" + (String)_config.ledConfig + "|input\n";
   values += "brightnesssensibility|" + (String)_config.luxSensitivity + "|input\n";
+  values += "animspeed|" + (String)_config.animSpeed + "|input\n";
+  values += "animbrightmin|" + (String)_config.animBrightnessMin + "|input\n";
+  values += "animbrightmax|" + (String)_config.animBrightnessMax + "|input\n";
 
 	_server.send(200, "text/plain", values);
 	//Serial.println(__FUNCTION__); 
@@ -180,9 +183,16 @@ void send_general_led()
         QTLed.setColorRandom((RandomColorMode)_server.arg(i).toInt());
       }
       if (_server.argName(i) == "brightnesssensibility")
-      {
         _config.luxSensitivity = _server.arg(i).toInt();
-      }
+
+      if (_server.argName(i) == "animspeed")
+        _config.animSpeed = constrain(_server.arg(i).toInt(), 1, 20);
+
+      if (_server.argName(i) == "animbrightmin")
+        _config.animBrightnessMin = constrain(_server.arg(i).toInt(), 0, 100);
+
+      if (_server.argName(i) == "animbrightmax")
+        _config.animBrightnessMax = constrain(_server.arg(i).toInt(), 0, 100);
     }
   }
   _server.send(200, "text/plain", "OK");

--- a/Page_general.h
+++ b/Page_general.h
@@ -186,7 +186,7 @@ void send_general_led()
         _config.luxSensitivity = _server.arg(i).toInt();
 
       if (_server.argName(i) == "animspeed")
-        _config.animSpeed = constrain(_server.arg(i).toInt(), 1, 20);
+        QTLed.setAnimSpeed(constrain(_server.arg(i).toInt(), 1, 20));
 
       if (_server.argName(i) == "animbrightmin")
         _config.animBrightnessMin = constrain(_server.arg(i).toInt(), 0, 100);

--- a/Page_index.h
+++ b/Page_index.h
@@ -1089,6 +1089,10 @@ const char PAGE_index[] PROGMEM = R"=====(
           removeDuplicateOptions(document.getElementById('lang'));
           removeDuplicateOptions(document.getElementById('mode'));
           removeDuplicateOptions(document.getElementById('animation'));
+          // Sync slider display values (setValues doesn't fire oninput)
+          document.getElementById('animspeedt').textContent = document.getElementById('animspeed').value;
+          document.getElementById('animbrightmint').textContent = document.getElementById('animbrightmin').value;
+          document.getElementById('animbrightmaxt').textContent = document.getElementById('animbrightmax').value;
           // Initialize color picker after values are loaded
           initializeColorPicker();
         });

--- a/Page_index.h
+++ b/Page_index.h
@@ -43,6 +43,14 @@ const char PAGE_index[] PROGMEM = R"=====(
           <span class="nav-icon">🔄</span>
           <span>Firmware Update</span>
         </button>
+        <a class="nav-item" href="/tetris.html" style="text-decoration:none;">
+          <span class="nav-icon">🎮</span>
+          <span>Tetris</span>
+        </a>
+        <a class="nav-item" href="/snake.html" style="text-decoration:none;">
+          <span class="nav-icon">🐍</span>
+          <span>Snake</span>
+        </a>
       </div>
     </nav>
 
@@ -216,6 +224,30 @@ const char PAGE_index[] PROGMEM = R"=====(
                   <label for="animation" class="form-label">Animation</label>
                   <select id="animation" name="animation" class="form-control" onchange="updateanimation()">
                   </select>
+                </div>
+
+                <div class="form-group">
+                  <label for="animspeed" class="form-label">Animation speed (1=slow, 20=fast)</label>
+                  <div class="range-group">
+                    <input type="range" id="animspeed" name="animspeed" class="range-input" min="1" max="20" step="1" oninput="updateanimspeed()">
+                    <div class="range-value" id="animspeedt">--</div>
+                  </div>
+                </div>
+
+                <div class="form-group">
+                  <label for="animbrightmin" class="form-label">Animation min brightness (%)</label>
+                  <div class="range-group">
+                    <input type="range" id="animbrightmin" name="animbrightmin" class="range-input" min="0" max="100" step="1" oninput="updateanimbrightmin()">
+                    <div class="range-value" id="animbrightmint">--</div>
+                  </div>
+                </div>
+
+                <div class="form-group">
+                  <label for="animbrightmax" class="form-label">Animation max brightness (%)</label>
+                  <div class="range-group">
+                    <input type="range" id="animbrightmax" name="animbrightmax" class="range-input" min="0" max="100" step="1" oninput="updateanimbrightmax()">
+                    <div class="range-value" id="animbrightmaxt">--</div>
+                  </div>
                 </div>
 
                 <button type="submit" class="btn btn-primary btn-block">Save Configuration</button>
@@ -778,6 +810,24 @@ const char PAGE_index[] PROGMEM = R"=====(
 
     function updateanimation() {
       setValues("/admin/led?animation=" + document.getElementById("animation").value);
+    }
+
+    function updateanimspeed() {
+      const value = document.getElementById("animspeed").value;
+      document.getElementById("animspeedt").textContent = value;
+      debouncedUpdate("animspeed", value);
+    }
+
+    function updateanimbrightmin() {
+      const value = document.getElementById("animbrightmin").value;
+      document.getElementById("animbrightmint").textContent = value;
+      debouncedUpdate("animbrightmin", value);
+    }
+
+    function updateanimbrightmax() {
+      const value = document.getElementById("animbrightmax").value;
+      document.getElementById("animbrightmaxt").textContent = value;
+      debouncedUpdate("animbrightmax", value);
     }
 
     function validatebrightnessauto() {

--- a/Page_index.h
+++ b/Page_index.h
@@ -781,6 +781,15 @@ const char PAGE_index[] PROGMEM = R"=====(
 
     function initializeColorPicker() {
       initColorPicker();
+      // setValues() sets colorText.value programmatically (no 'input' event fires),
+      // so we push the loaded color into colorInput here explicitly.
+      const colorInput = document.getElementById('color');
+      const colorText  = document.getElementById('colorText');
+      if (colorInput && colorText && colorText.value) {
+        let v = colorText.value.trim();
+        if (!v.startsWith('#')) v = '#' + v;
+        if (isValidHexColor(v)) colorInput.value = v;
+      }
     }
 
     function hexToRgb(hex) {

--- a/Page_index.h
+++ b/Page_index.h
@@ -191,10 +191,19 @@ const char PAGE_index[] PROGMEM = R"=====(
               </div>
 
             <div class="form-group">
-              <label for="color" class="form-label">Color</label>
-              <div class="color-picker-container">
-                <input type="color" id="color" name="color" class="color-picker-input">
+              <label class="form-label">Color</label>
+              <div style="display:flex;gap:0.75rem;align-items:center">
+                <div id="colorSwatch" class="cpicker-swatch" title="Pick color" style="width:3rem;height:2.5rem;background:#ff0000;border:2px solid #ccc;border-radius:4px;cursor:pointer;flex-shrink:0"></div>
                 <input type="text" id="colorText" class="color-text-input" placeholder="#FF0000" maxlength="7">
+                <input type="hidden" id="color" name="color">
+              </div>
+              <div id="cpickerPanel" class="cpicker-panel" style="display:none">
+                <div id="svSquare" class="cpicker-sv">
+                  <div class="cpicker-sv-white"></div>
+                  <div class="cpicker-sv-black"></div>
+                  <div id="svThumb" class="cpicker-sv-thumb"></div>
+                </div>
+                <input type="range" id="hueSlider" class="cpicker-hue" min="0" max="359" value="0">
               </div>
             </div>
 
@@ -498,43 +507,96 @@ const char PAGE_index[] PROGMEM = R"=====(
   <div class="overlay" id="overlay"></div>
 
   <script>
-    // Initialize color picker
+    // Custom color picker — HSV square + hue slider, no native <input type="color">
+    var _cpH=0, _cpS=1, _cpV=1, _cpInit=false;
+
+    function _cpHsvToHex(h,s,v) {
+      var i=Math.floor(h/60)%6, f=h/60-Math.floor(h/60);
+      var p=v*(1-s), q=v*(1-f*s), t=v*(1-(1-f)*s);
+      var rgb=[[v,t,p],[q,v,p],[p,v,t],[p,q,v],[t,p,v],[v,p,q]][i];
+      return '#'+rgb.map(function(x){return Math.round(x*255).toString(16).padStart(2,'0');}).join('');
+    }
+
+    function _cpHexToHsv(hex) {
+      var r=parseInt(hex.slice(1,3),16)/255, g=parseInt(hex.slice(3,5),16)/255, b=parseInt(hex.slice(5,7),16)/255;
+      var max=Math.max(r,g,b), min=Math.min(r,g,b), d=max-min, h=0;
+      if(d){if(max===r)h=((g-b)/d+(g<b?6:0))*60; else if(max===g)h=((b-r)/d+2)*60; else h=((r-g)/d+4)*60;}
+      return {h:h, s:max?d/max:0, v:max};
+    }
+
+    function _cpApply(send) {
+      var hex=_cpHsvToHex(_cpH,_cpS,_cpV);
+      var sw=document.getElementById('colorSwatch');
+      var ct=document.getElementById('colorText');
+      var ci=document.getElementById('color');
+      var sq=document.getElementById('svSquare');
+      var th=document.getElementById('svThumb');
+      var hs=document.getElementById('hueSlider');
+      if(sw) sw.style.backgroundColor=hex;
+      if(ct) ct.value=hex;
+      if(ci) ci.value=hex;
+      if(sq) sq.style.backgroundColor='hsl('+Math.round(_cpH)+',100%,50%)';
+      if(th){th.style.left=(_cpS*100)+'%'; th.style.top=((1-_cpV)*100)+'%';}
+      if(hs) hs.value=_cpH;
+      if(send) updatecolor(hex);
+    }
+
+    function _cpSetFromHex(hex) {
+      if(!isValidHexColor(hex)) return;
+      var hsv=_cpHexToHsv(hex);
+      _cpH=hsv.h; _cpS=hsv.s; _cpV=hsv.v;
+      _cpApply(false);
+    }
+
     function initColorPicker() {
-      const colorInput = document.getElementById('color');
-      const colorText = document.getElementById('colorText');
-
-      if (colorInput && colorText) {
-        function syncTextToColorPicker() {
-          const currentColorValue = colorText.value;
-          if (currentColorValue) {
-            let value = currentColorValue.trim();
-            if (!value.startsWith('#')) value = '#' + value;
-            if (isValidHexColor(value)) {
-              colorInput.value = value;
-            }
-          }
-        }
-
-        // Sync color picker to text input
-        colorInput.addEventListener('input', function(e) {
-          colorText.value = e.target.value;
-          updatecolor(e.target.value);
-        });
-
-        // Sync text input to color picker
-        colorText.addEventListener('input', function(e) {
-          syncTextToColorPicker();
-          let value = e.target.value.trim();
-          if (!value.startsWith('#')) value = '#' + value;
-          if (isValidHexColor(value)) {
-            updatecolor(value);
-          }
-        });
-
-        // Sync on load
-        setTimeout(syncTextToColorPicker, 100);
-        setTimeout(syncTextToColorPicker, 500);
+      if(_cpInit) {
+        var ct=document.getElementById('colorText');
+        if(ct && ct.value) _cpSetFromHex(ct.value.trim().startsWith('#')?ct.value.trim():'#'+ct.value.trim());
+        return;
       }
+      _cpInit=true;
+      var swatch=document.getElementById('colorSwatch');
+      var panel=document.getElementById('cpickerPanel');
+      var sq=document.getElementById('svSquare');
+      var hs=document.getElementById('hueSlider');
+      var ct=document.getElementById('colorText');
+      var panelOpen=false;
+
+      swatch.addEventListener('click', function(e) {
+        e.stopPropagation();
+        panelOpen=!panelOpen;
+        panel.style.display=panelOpen?'block':'none';
+      });
+      document.addEventListener('click', function(e) {
+        if(panelOpen && !panel.contains(e.target) && e.target!==swatch) {
+          panelOpen=false; panel.style.display='none';
+        }
+      });
+
+      var svDrag=false;
+      function onSV(e) {
+        e.preventDefault();
+        var rect=sq.getBoundingClientRect();
+        var cx=e.touches?e.touches[0].clientX:e.clientX;
+        var cy=e.touches?e.touches[0].clientY:e.clientY;
+        _cpS=Math.max(0,Math.min(1,(cx-rect.left)/rect.width));
+        _cpV=Math.max(0,Math.min(1,1-(cy-rect.top)/rect.height));
+        _cpApply(true);
+      }
+      sq.addEventListener('mousedown',  function(e){svDrag=true; onSV(e);});
+      sq.addEventListener('touchstart', function(e){svDrag=true; onSV(e);},{passive:false});
+      document.addEventListener('mousemove',  function(e){if(svDrag) onSV(e);});
+      document.addEventListener('touchmove',  function(e){if(svDrag) onSV(e);},{passive:false});
+      document.addEventListener('mouseup',    function(){svDrag=false;});
+      document.addEventListener('touchend',   function(){svDrag=false;});
+
+      hs.addEventListener('input', function(){_cpH=parseInt(this.value); _cpApply(true);});
+
+      ct.addEventListener('input', function() {
+        var v=this.value.trim();
+        if(!v.startsWith('#')) v='#'+v;
+        if(isValidHexColor(v)){_cpSetFromHex(v); updatecolor(v);}
+      });
     }
 
     // Dashboard Management
@@ -781,14 +843,11 @@ const char PAGE_index[] PROGMEM = R"=====(
 
     function initializeColorPicker() {
       initColorPicker();
-      // setValues() sets colorText.value programmatically (no 'input' event fires),
-      // so we push the loaded color into colorInput here explicitly.
-      const colorInput = document.getElementById('color');
-      const colorText  = document.getElementById('colorText');
-      if (colorInput && colorText && colorText.value) {
-        let v = colorText.value.trim();
-        if (!v.startsWith('#')) v = '#' + v;
-        if (isValidHexColor(v)) colorInput.value = v;
+      var ct=document.getElementById('colorText');
+      if(ct && ct.value) {
+        var v=ct.value.trim();
+        if(!v.startsWith('#')) v='#'+v;
+        _cpSetFromHex(v);
       }
     }
 
@@ -1192,7 +1251,7 @@ const char PAGE_index[] PROGMEM = R"=====(
 
     // Initialize app
     window.onload = function() {
-      load("style.css", "css", function() {
+      load("style.css?t="+Date.now(), "css", function() {
         // Load saved theme
         loadTheme();
 

--- a/Page_network.h
+++ b/Page_network.h
@@ -75,7 +75,8 @@ void send_network_configuration_values_html()
   String values = "";
 
   values += "ssid|" + (String)_config.ssid + "|input\n";
-  values += "password|" + (String)_config.password + "|input\n";
+  values += "password||input\n";
+  values += "appassword||input\n";
   values += "ipaddress|" + (String)_config.IP[0] + "." + (String)_config.IP[1] + "." + (String)_config.IP[2] + "." + (String)_config.IP[3] + "|input\n";
   values += "netmask|" + (String)_config.Netmask[0] + "." + (String)_config.Netmask[1] + "." + (String)_config.Netmask[2] + "." + (String)_config.Netmask[3] + "|input\n";
   values += "gateway|" + (String)_config.Gateway[0] + "." + (String)_config.Gateway[1] + "." + (String)_config.Gateway[2] + "." + (String)_config.Gateway[3] + "|input\n";

--- a/Page_snake.h
+++ b/Page_snake.h
@@ -1,0 +1,150 @@
+const char PAGE_snake[] PROGMEM = R"=====(
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<style>
+*{box-sizing:border-box;-webkit-tap-highlight-color:transparent;}
+html,body{margin:0;padding:0;width:100%;height:100%;background:#111;color:#eee;font-family:sans-serif;overflow:hidden;}
+#wrap{display:flex;flex-direction:column;height:100%;padding:6px;gap:6px;}
+#topbar{display:flex;align-items:center;gap:6px;flex-shrink:0;}
+#score{flex:1;font-size:13px;text-align:right;color:#aaa;}
+#status{font-size:12px;color:#fa0;text-align:center;flex-shrink:0;}
+#gamearea{display:flex;flex:1;align-items:center;justify-content:center;min-height:0;}
+.btn{background:#222;color:#fff;border:2px solid #444;border-radius:10px;
+  cursor:pointer;touch-action:manipulation;user-select:none;-webkit-user-select:none;
+  display:flex;align-items:center;justify-content:center;}
+.btn:active{background:#444;}
+.tbtn{height:40px;padding:0 10px;font-size:13px;}
+.start{border-color:#2a5;background:#163;}
+.exit{border-color:#844;background:#422;}
+.btn svg{display:block;margin:auto;}
+.dpad{display:grid;grid-template-columns:repeat(3,90px);grid-template-rows:repeat(3,90px);gap:8px;}
+.dpad-btn{border-color:#555;}
+</style>
+<div id="wrap">
+  <div id="topbar">
+    <div class="btn tbtn start" ontouchstart="doStart(event)" onmousedown="doStart(event)">Start</div>
+    <div class="btn tbtn exit"  ontouchstart="doExit(event)"  onmousedown="doExit(event)">Exit</div>
+    <div id="status">READY</div>
+    <div id="score">Score: <b id="sc">0</b></div>
+  </div>
+  <div id="gamearea">
+    <div class="dpad">
+      <div></div>
+      <div class="btn dpad-btn" ontouchstart="aT('up',event)"    onmousedown="aMD('up')"   ><svg width="50" height="50" viewBox="0 0 24 24"><polygon points="2,22 22,22 12,2"  fill="white"/></svg></div>
+      <div></div>
+      <div class="btn dpad-btn" ontouchstart="aT('left',event)"  onmousedown="aMD('left')" ><svg width="50" height="50" viewBox="0 0 24 24"><polygon points="22,2 22,22 2,12"  fill="white"/></svg></div>
+      <div></div>
+      <div class="btn dpad-btn" ontouchstart="aT('right',event)" onmousedown="aMD('right')"><svg width="50" height="50" viewBox="0 0 24 24"><polygon points="2,2 2,22 22,12"   fill="white"/></svg></div>
+      <div></div>
+      <div class="btn dpad-btn" ontouchstart="aT('down',event)"  onmousedown="aMD('down')" ><svg width="50" height="50" viewBox="0 0 24 24"><polygon points="2,2 22,2 12,22"   fill="white"/></svg></div>
+      <div></div>
+    </div>
+  </div>
+</div>
+<script>
+function req(u){var x=new XMLHttpRequest();x.open('GET',u,true);x.send();return x;}
+function aT(a,e){e.preventDefault();req('/admin/snake?action='+a);}
+function aMD(a){req('/admin/snake?action='+a);}
+function doStart(e){e.preventDefault();req('/admin/snake?action=start');}
+function doExit(e){e.preventDefault();req('/admin/snake?action=exit');setTimeout(function(){window.location='/';},200);}
+function getState(){
+  var x=new XMLHttpRequest();
+  x.onreadystatechange=function(){
+    if(x.readyState!=4||x.status!=200)return;
+    x.responseText.split('\n').forEach(function(l){
+      var p=l.split('|');if(p.length<2)return;
+      if(p[0]=='sc'){var e=document.getElementById('sc');if(e)e.innerHTML=p[1];}
+      else if(p[0]=='status'){document.getElementById('status').innerHTML=p[1];}
+    });
+  };
+  x.open('GET','/admin/snakestate',true);x.send();
+}
+window.onload=function(){
+  load('style.css','css',function(){
+    req('/admin/snake?action=start');
+    setInterval(getState,400);
+  });
+};
+function load(e,t,n){if('css'==t){var a=document.createElement('link');a.href=e;a.rel='stylesheet';a.type='text/css';a.async=!1;a.onload=function(){n()};document.getElementsByTagName('head')[0].appendChild(a)}}
+document.addEventListener('keydown',function(e){
+  var m={'ArrowUp':'up','ArrowDown':'down','ArrowLeft':'left','ArrowRight':'right'};
+  if(m[e.key]){e.preventDefault();req('/admin/snake?action='+m[e.key]);}
+});
+var _gp={};
+function pollGP(){
+  var gs=navigator.getGamepads?navigator.getGamepads():[];
+  for(var i=0;i<gs.length;i++){
+    var g=gs[i];if(!g)continue;
+    [{b:12,a:'up'},{b:13,a:'down'},{b:14,a:'left'},{b:15,a:'right'}].forEach(function(m){
+      var p=g.buttons[m.b]&&g.buttons[m.b].pressed,k=i+'b'+m.b;
+      if(p&&!_gp[k])req('/admin/snake?action='+m.a);_gp[k]=p;
+    });
+    var ax=g.axes[0]||0,ay=g.axes[1]||0;
+    var h=ax<-0.5?'left':ax>0.5?'right':'',v=ay<-0.5?'up':ay>0.5?'down':'';
+    if(h&&_gp['h'+i]!==h)req('/admin/snake?action='+h);
+    if(v&&_gp['v'+i]!==v)req('/admin/snake?action='+v);
+    _gp['h'+i]=h;_gp['v'+i]=v;
+  }
+  requestAnimationFrame(pollGP);
+}
+window.addEventListener('gamepadconnected',function(){pollGP();});
+</script>
+)=====";
+
+void send_snake_html()
+{
+  _server.sendHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+  _server.sendHeader("Pragma", "no-cache");
+  _server.sendHeader("Expires", "-1");
+  _server.send_P(200, "text/html", PAGE_snake);
+}
+
+void send_snake_action()
+{
+  String a = _server.arg("action");
+
+  if (a == "exit") {
+    QTLed.snakeStop();
+    _server.send(200, "text/plain", "exit");
+    return;
+  }
+
+  if (a == "start") {
+    if (!QTLed.isSnakeActive()) QTLed.snakeStart();
+    else if (LedStripAnimationSnake::instance)
+      LedStripAnimationSnake::instance->action(LedStripAnimationSnake::ACT_START);
+    _server.send(200, "text/plain", "ok");
+    return;
+  }
+
+  if (LedStripAnimationSnake::instance == nullptr || !QTLed.isSnakeActive()) {
+    _server.send(200, "text/plain", "inactive");
+    return;
+  }
+
+  LedStripAnimationSnake::SnaAction act = LedStripAnimationSnake::ACT_NONE;
+  if      (a == "up")    act = LedStripAnimationSnake::ACT_UP;
+  else if (a == "down")  act = LedStripAnimationSnake::ACT_DOWN;
+  else if (a == "left")  act = LedStripAnimationSnake::ACT_LEFT;
+  else if (a == "right") act = LedStripAnimationSnake::ACT_RIGHT;
+  LedStripAnimationSnake::instance->action(act);
+  _server.send(200, "text/plain", "ok");
+}
+
+void send_snake_state()
+{
+  String s = "";
+  if (LedStripAnimationSnake::instance) {
+    LedStripAnimationSnake *t = LedStripAnimationSnake::instance;
+    s += "sc|"     + String(t->getScore()) + "\n";
+    switch (t->getState()) {
+      case LedStripAnimationSnake::STATE_PLAYING:   s += "status|PLAYING\n";   break;
+      case LedStripAnimationSnake::STATE_GAME_OVER: s += "status|GAME OVER\n"; break;
+      default:                                      s += "status|READY\n";     break;
+    }
+  }
+  _server.sendHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+  _server.sendHeader("Pragma", "no-cache");
+  _server.sendHeader("Expires", "-1");
+  _server.send(200, "text/plain", s);
+}

--- a/Page_style.css.h
+++ b/Page_style.css.h
@@ -566,6 +566,46 @@ body {
   box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
 }
 
+.cpicker-swatch {
+  width:3rem; height:2.5rem;
+  border:2px solid var(--border);
+  border-radius:var(--radius-sm);
+  cursor:pointer; flex-shrink:0;
+  background:#ff0000;
+  transition:border-color 0.15s;
+}
+.cpicker-swatch:hover { border-color:var(--primary-color); }
+.cpicker-panel { margin-top:0.5rem; user-select:none; -webkit-user-select:none; }
+.cpicker-sv {
+  position:relative; width:100%; height:160px;
+  border-radius:var(--radius-sm);
+  overflow:hidden; cursor:crosshair; touch-action:none;
+}
+.cpicker-sv-white { position:absolute; inset:0; background:linear-gradient(to right,#fff,transparent); }
+.cpicker-sv-black { position:absolute; inset:0; background:linear-gradient(to bottom,transparent,#000); }
+.cpicker-sv-thumb {
+  position:absolute; width:14px; height:14px;
+  border:2px solid #fff; border-radius:50%;
+  box-shadow:0 0 3px rgba(0,0,0,.6);
+  transform:translate(-50%,-50%); pointer-events:none;
+}
+.cpicker-hue {
+  width:100%; margin-top:0.5rem; height:1.5rem;
+  -webkit-appearance:none; appearance:none;
+  background:linear-gradient(to right,#f00,#ff0,#0f0,#0ff,#00f,#f0f,#f00);
+  border-radius:var(--radius-sm); cursor:pointer; border:none; outline:none;
+}
+.cpicker-hue::-webkit-slider-thumb {
+  -webkit-appearance:none; width:18px; height:1.5rem;
+  background:rgba(255,255,255,.9); border:2px solid #888;
+  border-radius:4px; cursor:pointer;
+}
+.cpicker-hue::-moz-range-thumb {
+  width:18px; height:1.5rem;
+  background:rgba(255,255,255,.9); border:2px solid #888;
+  border-radius:4px; cursor:pointer;
+}
+
 .color-text-input {
   flex: 1;
   padding: 0.75rem;

--- a/Page_tetris.h
+++ b/Page_tetris.h
@@ -1,0 +1,206 @@
+const char PAGE_tetris[] PROGMEM = R"=====(
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<style>
+*{box-sizing:border-box;-webkit-tap-highlight-color:transparent;}
+html,body{margin:0;padding:0;width:100%;height:100%;background:#111;color:#eee;font-family:sans-serif;overflow:hidden;}
+#wrap{display:flex;flex-direction:column;height:100%;padding:6px;gap:6px;}
+#topbar{display:flex;align-items:center;gap:6px;flex-shrink:0;}
+#score{flex:1;font-size:13px;text-align:right;color:#aaa;}
+#status{font-size:12px;color:#fa0;text-align:center;flex-shrink:0;}
+#gamearea{display:flex;flex:1;gap:6px;min-height:0;}
+.col{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:8px;}
+.btn{background:#222;color:#fff;border:2px solid #444;border-radius:10px;
+  cursor:pointer;touch-action:manipulation;user-select:none;-webkit-user-select:none;
+  display:flex;align-items:center;justify-content:center;font-size:15px;}
+.btn:active{background:#444;}
+.tbtn{height:40px;padding:0 10px;font-size:13px;}
+.start{border-color:#2a5;background:#163;}
+.exit{border-color:#844;background:#422;}
+.dpad-row{display:flex;gap:8px;width:100%;}
+.dpad-btn{flex:1;height:110px;}
+.dpad-down{width:100%;height:72px;}
+.rotate-btn{width:140px;height:140px;border-color:#06c;}
+.btn svg{display:block;margin:auto;}
+#nextlabel{font-size:11px;color:#888;margin-bottom:2px;text-align:center;width:100%;}
+#nextcanvas{border:1px solid #333;background:#000;border-radius:6px;display:block;margin:0 auto;}
+</style>
+<div id="wrap">
+  <div id="topbar">
+    <div class="btn tbtn start" ontouchstart="doStart(event)" onmousedown="doStart(event)">Start</div>
+    <div class="btn tbtn exit"  ontouchstart="doExit(event)"  onmousedown="doExit(event)">Exit</div>
+    <div id="status">READY</div>
+    <div id="score">Score: <b id="sc">0</b> | Lines: <b id="ln">0</b> | Lv.<b id="lv">0</b></div>
+  </div>
+  <div id="gamearea">
+    <div class="col" style="flex:1.6">
+      <div class="dpad-row">
+        <div class="btn dpad-btn" ontouchstart="hT('left',event)"  ontouchend="rel(event)"  ontouchcancel="rel(event)"  onmousedown="hM('left',this)"  onmouseup="relM()" onmouseleave="relM()"><svg width="44" height="44" viewBox="0 0 24 24"><polygon points="18,3 18,21 4,12" fill="white"/></svg></div>
+        <div class="btn dpad-btn" ontouchstart="hT('right',event)" ontouchend="rel(event)"  ontouchcancel="rel(event)"  onmousedown="hM('right',this)" onmouseup="relM()" onmouseleave="relM()"><svg width="44" height="44" viewBox="0 0 24 24"><polygon points="6,3 6,21 20,12" fill="white"/></svg></div>
+      </div>
+      <div class="btn dpad-down" ontouchstart="hT('down',event)" ontouchend="rel(event)" ontouchcancel="rel(event)" onmousedown="hM('down',this)" onmouseup="relM()" onmouseleave="relM()"><svg width="44" height="44" viewBox="0 0 24 24"><polygon points="3,6 21,6 12,20" fill="white"/></svg></div>
+    </div>
+    <div class="col" style="flex:1.4">
+      <div id="nextlabel">NEXT</div>
+      <canvas id="nextcanvas" width="180" height="180"></canvas>
+    </div>
+    <div class="col" style="flex:0.8">
+      <div class="btn rotate-btn" ontouchstart="aT('rotate',event)" onmousedown="aMD('rotate')"><svg width="80" height="80" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"/><path d="M20.5 15a9 9 0 1 1-3-7.7L23 10"/></svg></div>
+    </div>
+  </div>
+</div>
+<script>
+var _ht=null;
+var SHAPES=[
+  [[1,1,1,1],[0,0,0,0],[0,0,0,0],[0,0,0,0]],
+  [[0,1,1,0],[0,1,1,0],[0,0,0,0],[0,0,0,0]],
+  [[0,1,0,0],[1,1,1,0],[0,0,0,0],[0,0,0,0]],
+  [[0,1,1,0],[1,1,0,0],[0,0,0,0],[0,0,0,0]],
+  [[1,1,0,0],[0,1,1,0],[0,0,0,0],[0,0,0,0]],
+  [[1,0,0,0],[1,1,1,0],[0,0,0,0],[0,0,0,0]],
+  [[0,0,1,0],[1,1,1,0],[0,0,0,0],[0,0,0,0]]
+];
+var COLORS=['#0CC','#CC0','#90C','#0C0','#C00','#00C','#C60'];
+function req(u){var x=new XMLHttpRequest();x.open('GET',u,true);x.send();return x;}
+function aT(a,e){e.preventDefault();req('/admin/tetris?action='+a);}
+function aMD(a){req('/admin/tetris?action='+a);}
+function hT(a,e){e.preventDefault();req('/admin/tetris?action='+a);_ht=setInterval(function(){req('/admin/tetris?action='+a);},150);}
+function hM(a,b){req('/admin/tetris?action='+a);_ht=setInterval(function(){req('/admin/tetris?action='+a);},150);}
+function rel(e){e.preventDefault();if(_ht){clearInterval(_ht);_ht=null;}}
+function relM(){if(_ht){clearInterval(_ht);_ht=null;}}
+function doStart(e){e.preventDefault();req('/admin/tetris?action=start');}
+function doExit(e){e.preventDefault();req('/admin/tetris?action=exit');setTimeout(function(){window.location='/';},200);}
+function drawNext(i){
+  var cv=document.getElementById('nextcanvas');
+  if(!cv)return;
+  var ctx=cv.getContext('2d'),sz=cv.width/4;
+  ctx.clearRect(0,0,cv.width,cv.height);
+  if(i<0||i>6)return;
+  ctx.fillStyle=COLORS[i];
+  var s=SHAPES[i];
+  var minR=4,maxR=-1,minC=4,maxC=-1;
+  for(var r=0;r<4;r++)for(var c=0;c<4;c++)
+    if(s[r][c]){if(r<minR)minR=r;if(r>maxR)maxR=r;if(c<minC)minC=c;if(c>maxC)maxC=c;}
+  var ox=(cv.width-(maxC-minC+1)*sz)/2;
+  var oy=(cv.height-(maxR-minR+1)*sz)/2;
+  for(var r=0;r<4;r++)for(var c=0;c<4;c++)
+    if(s[r][c])ctx.fillRect(ox+(c-minC)*sz+1,oy+(r-minR)*sz+1,sz-2,sz-2);
+}
+function getState(){
+  var x=new XMLHttpRequest();
+  x.onreadystatechange=function(){
+    if(x.readyState!=4||x.status!=200)return;
+    x.responseText.split('\n').forEach(function(l){
+      var p=l.split('|');if(p.length<2)return;
+      if(p[0]=='sc'||p[0]=='ln'||p[0]=='lv'){var e=document.getElementById(p[0]);if(e)e.innerHTML=p[1];}
+      else if(p[0]=='status'){document.getElementById('status').innerHTML=p[1];}
+      else if(p[0]=='next'){drawNext(parseInt(p[1]));}
+    });
+  };
+  x.open('GET','/admin/tetrisstate',true);x.send();
+}
+window.onload=function(){
+  load('style.css','css',function(){
+    req('/admin/tetris?action=start');
+    setInterval(getState,400);
+  });
+};
+function load(e,t,n){if('css'==t){var a=document.createElement('link');a.href=e;a.rel='stylesheet';a.type='text/css';a.async=!1;a.onload=function(){n()};document.getElementsByTagName('head')[0].appendChild(a)}}
+var _kr={};
+document.addEventListener('keydown',function(e){
+  if(e.repeat)return;
+  if(e.key==='ArrowLeft'){e.preventDefault();req('/admin/tetris?action=left');_kr.left=setInterval(function(){req('/admin/tetris?action=left');},150);}
+  else if(e.key==='ArrowRight'){e.preventDefault();req('/admin/tetris?action=right');_kr.right=setInterval(function(){req('/admin/tetris?action=right');},150);}
+  else if(e.key==='ArrowDown'){e.preventDefault();req('/admin/tetris?action=down');_kr.down=setInterval(function(){req('/admin/tetris?action=down');},150);}
+  else if(e.key==='ArrowUp'||e.key===' '||e.key==='z'||e.key==='a'){e.preventDefault();req('/admin/tetris?action=rotate');}
+});
+document.addEventListener('keyup',function(e){
+  if(e.key==='ArrowLeft'&&_kr.left){clearInterval(_kr.left);_kr.left=null;}
+  if(e.key==='ArrowRight'&&_kr.right){clearInterval(_kr.right);_kr.right=null;}
+  if(e.key==='ArrowDown'&&_kr.down){clearInterval(_kr.down);_kr.down=null;}
+});
+var _gp={},_gpR={};
+function pollGP(){
+  var now=Date.now(),gs=navigator.getGamepads?navigator.getGamepads():[];
+  for(var i=0;i<gs.length;i++){
+    var g=gs[i];if(!g)continue;
+    [0,1,12].forEach(function(b){var p=g.buttons[b]&&g.buttons[b].pressed,k=i+'b'+b;if(p&&!_gp[k])req('/admin/tetris?action=rotate');_gp[k]=p;});
+    [{b:14,a:'left'},{b:15,a:'right'},{b:13,a:'down'}].forEach(function(m){
+      var p=g.buttons[m.b]&&g.buttons[m.b].pressed,k=i+'b'+m.b;
+      if(p){if(!_gp[k]){req('/admin/tetris?action='+m.a);_gpR[k]=now+200;}else if(now>=(_gpR[k]||0)){req('/admin/tetris?action='+m.a);_gpR[k]=now+150;}}
+      _gp[k]=p;
+    });
+    var ax=g.axes[0]||0,ay=g.axes[1]||0,h=ax<-0.5?'left':ax>0.5?'right':'';
+    if(h){if(!_gp['h'+i]){req('/admin/tetris?action='+h);_gpR['h'+i]=now+200;}else if(now>=(_gpR['h'+i]||0)){req('/admin/tetris?action='+h);_gpR['h'+i]=now+150;}}
+    _gp['h'+i]=h;
+    var vd=ay>0.5;if(vd){if(!_gp['v'+i]){req('/admin/tetris?action=down');_gpR['v'+i]=now+200;}else if(now>=(_gpR['v'+i]||0)){req('/admin/tetris?action=down');_gpR['v'+i]=now+150;}}
+    _gp['v'+i]=vd;
+    var vu=ay<-0.5;if(vu&&!_gp['vu'+i])req('/admin/tetris?action=rotate');_gp['vu'+i]=vu;
+  }
+  requestAnimationFrame(pollGP);
+}
+window.addEventListener('gamepadconnected',function(){pollGP();});
+</script>
+)=====";
+
+void send_tetris_html()
+{
+  _server.sendHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+  _server.sendHeader("Pragma", "no-cache");
+  _server.sendHeader("Expires", "-1");
+  _server.send_P(200, "text/html", PAGE_tetris);
+}
+
+void send_tetris_action()
+{
+  String a = _server.arg("action");
+
+  if (a == "exit") {
+    QTLed.tetrisStop();
+    _server.send(200, "text/plain", "exit");
+    return;
+  }
+
+  if (a == "start") {
+    if (!QTLed.isTetrisActive()) QTLed.tetrisStart();
+    else if (LedStripAnimationTetris::instance)
+      LedStripAnimationTetris::instance->action(LedStripAnimationTetris::ACT_START);
+    _server.send(200, "text/plain", "ok");
+    return;
+  }
+
+  if (LedStripAnimationTetris::instance == nullptr || !QTLed.isTetrisActive()) {
+    _server.send(200, "text/plain", "inactive");
+    return;
+  }
+
+  LedStripAnimationTetris::TetAction act = LedStripAnimationTetris::ACT_NONE;
+  if      (a == "left")   act = LedStripAnimationTetris::ACT_LEFT;
+  else if (a == "right")  act = LedStripAnimationTetris::ACT_RIGHT;
+  else if (a == "rotate") act = LedStripAnimationTetris::ACT_ROTATE;
+  else if (a == "down")   act = LedStripAnimationTetris::ACT_DOWN;
+  else if (a == "drop")   act = LedStripAnimationTetris::ACT_DROP;
+  LedStripAnimationTetris::instance->action(act);
+  _server.send(200, "text/plain", "ok");
+}
+
+void send_tetris_state()
+{
+  String s = "";
+  if (LedStripAnimationTetris::instance) {
+    LedStripAnimationTetris *t = LedStripAnimationTetris::instance;
+    s += "sc|"     + String(t->getScore()) + "\n";
+    s += "ln|"     + String(t->getLines()) + "\n";
+    s += "lv|"     + String(t->getLevel()) + "\n";
+    s += "next|"   + String(t->getNext())  + "\n";
+    switch (t->getState()) {
+      case LedStripAnimationTetris::STATE_PLAYING:   s += "status|PLAYING\n";   break;
+      case LedStripAnimationTetris::STATE_GAME_OVER: s += "status|GAME OVER\n"; break;
+      default:                                       s += "status|READY\n";     break;
+    }
+  }
+  _server.sendHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+  _server.sendHeader("Pragma", "no-cache");
+  _server.sendHeader("Expires", "-1");
+  _server.send(200, "text/plain", s);
+}

--- a/TexTime.ino
+++ b/TexTime.ino
@@ -258,8 +258,11 @@ void setup() {
         if (_server.argName(i) == "colorrandom") _config.colorRandom = _server.arg(i).toInt();
         if (_server.argName(i) == "ledconfig") _config.ledConfig = _server.arg(i).toInt();
         if (_server.argName(i) == "brightnesssensibility") _config.luxSensitivity = _server.arg(i).toInt();
+        if (_server.argName(i) == "animspeed") _config.animSpeed = constrain(_server.arg(i).toInt(), 1, 20);
+        if (_server.argName(i) == "animbrightmin") _config.animBrightnessMin = constrain(_server.arg(i).toInt(), 0, 100);
+        if (_server.argName(i) == "animbrightmax") _config.animBrightnessMax = constrain(_server.arg(i).toInt(), 0, 100);
       }
-      
+
       WriteConfig();
       QTLed.begin();
       QTLed.setAutomaticBrightness(_config.brightnessAuto);

--- a/TexTime.ino
+++ b/TexTime.ino
@@ -45,6 +45,8 @@
 #include "Page_mqtt.h"
 #include "Page_script.js.h"
 #include "Page_style.css.h"
+#include "Page_tetris.h"
+#include "Page_snake.h"
 
 
 
@@ -52,12 +54,8 @@ extern "C" {
 #include "user_interface.h"
 }
 
-IPAddress _apIP(192, 168, 1, 1);
-IPAddress _apNetMsk(255, 255, 255, 0);
-
 //*** Normal code definition here ...
 void setup() {
-  String chipID;
   bool CFG_saved = false;
 
   // No need to set this until option is set in arduino/visualmicro
@@ -71,7 +69,7 @@ void setup() {
   Serial.println("Booting");
 
   // Config load 
-  EEPROM.begin(1024); // define an EEPROM space of 1024Bytes to store data
+  EEPROM.begin(EEPROM_SIZE);
   CFG_saved = ReadConfig();
   if (!CFG_saved)
   {
@@ -96,12 +94,16 @@ void setup() {
     _config.brightness = 128; // [0:255]
     _config.brightnessAutoMinDay = 30; // [0:255]
     _config.brightnessAutoMinNight = 0; // [0:255]
+    _config.brightnessMax = 255; // [0:255]
     _config.color[0] = 255; // R
     _config.color[1] = 255; // G
     _config.color[2] = 255; // B
     _config.color[3] = 255; // W
     _config.mode = 1;
     _config.animation = 0;
+    _config.animSpeed = 10;
+    _config.animBrightnessMin = 10;
+    _config.animBrightnessMax = 100;
     _config.ledConfig = 0;
     _config.luxSensitivity = 40;
     _config.language = 0;
@@ -111,6 +113,9 @@ void setup() {
     _config.MQTTPassword = "";
     _config.MQTTPort = 1883;
     _config.MQTTPubInterval = 120; // in sec
+
+    _config.APPassword = AP_DEFAULT_PASSWORD;
+    WriteConfig();
   }
 
   // Start led strip
@@ -128,7 +133,7 @@ void setup() {
   //printConfig();
 
   // Configure WiFi
-  WiFiMgr.setAPssid("TexTime-" + String(ESP.getChipId(), HEX));
+  WiFiMgr.setAPssid("TexTime-" + String(ESP.getChipId(), HEX), _config.APPassword);
 
   if (!_config.dhcp)
   {
@@ -139,7 +144,7 @@ void setup() {
   }
 
   // Start WiFi
-  WiFiMgr.tryToConnect(_config.ssid, _config.password, &_config.DeviceName[0]);
+  WiFiMgr.tryToConnect(_config.ssid, _config.password, _config.DeviceName);
 
   // Start HTTP Server for configuration
   _server.on("/", []() {
@@ -217,7 +222,15 @@ void setup() {
   _server.on("/admin/generalledconfigvalues", send_general_ledconfig_values_html);
 
   _server.on("/admin/led", send_general_led);
-  
+
+  _server.on("/tetris.html", send_tetris_html);
+  _server.on("/admin/tetris", send_tetris_action);
+  _server.on("/admin/tetrisstate", send_tetris_state);
+
+  _server.on("/snake.html", send_snake_html);
+  _server.on("/admin/snake", send_snake_action);
+  _server.on("/admin/snakestate", send_snake_state);
+
   // Async save endpoints
   _server.on("/admin/save/general", HTTP_POST, []() {
     if (_server.args() > 0) {
@@ -268,7 +281,8 @@ void setup() {
       _config.dhcp = false;
       for (uint8_t i = 0; i < _server.args(); i++) {
         if (_server.argName(i) == "ssid") _config.ssid = _server.arg(i);
-        if (_server.argName(i) == "password") _config.password = _server.arg(i);
+        if (_server.argName(i) == "password") { String p = _server.arg(i); if (p.length() > 0) _config.password = p; }
+        if (_server.argName(i) == "appassword") { String p = _server.arg(i); if (p.length() >= 8) _config.APPassword = p; }
         if (_server.argName(i) == "ipaddress") {
           // Parse IP address string like "192.168.1.100"
           String ip = _server.arg(i);
@@ -449,7 +463,7 @@ void setup() {
   // MQTT configuration
   if (_config.MQTTPubInterval < 1) _config.MQTTPubInterval = 1;
   _mqttWifiClient.setNoDelay(true);
-  _mqttWifiClient.setTimeout(MQTT_SOCKET_TIMEOUT * 1000);
+  _mqttWifiClient.setTimeout((unsigned long)MQTT_SOCKET_TIMEOUT * 1000UL);
   _mqtt.setServer(_config.MQTTServer.c_str(), _config.MQTTPort);
   _mqtt.setCallback(mqttCallback);
 

--- a/WiFiMgr.cpp
+++ b/WiFiMgr.cpp
@@ -9,7 +9,7 @@ WiFiMgrClass::WiFiMgrClass()
   , _STAkey("")
   , _devicename("")
   , _STAlastTry(0)
-  , _STAtryTimeout(10 * 1000)
+  , _STAtryTimeout(30 * 1000)
   , _APssid("")
   , _APkey("")
   , _APlastTry(0)
@@ -45,7 +45,7 @@ void WiFiMgrClass::setSTAIPip(IPAddress ip, IPAddress gw, IPAddress mask, IPAddr
   setSTAIPdhcp(false);
 }
 
-void WiFiMgrClass::tryToConnect(String ssid, String key, String devicename)
+void WiFiMgrClass::tryToConnect(const String& ssid, const String& key, const String& devicename)
 {
   _STAssid = ssid;
   _STAkey = key;
@@ -70,9 +70,10 @@ void WiFiMgrClass::tryToReconnect()
   wifi_station_set_hostname(_devicename.c_str()); //See more at : http ://www.esp8266.com/viewtopic.php?f=29&t=11124#sthash.458xtq2U.dpuf
 
   Serial.print("Trying to connect to ");
-  Serial.print(_STAssid.c_str());
-  Serial.print(" with key : ");
-  Serial.println(_STAkey.c_str());
+  Serial.println(_STAssid.c_str());
+
+  if (!_STADHCP)
+    WiFi.config(_STAIPip, _STAIPgw, _STAIPmask, _STAIPdns);
 
   WiFi.begin(_STAssid, _STAkey);
 
@@ -83,15 +84,16 @@ void WiFiMgrClass::tryToReconnect()
 
 void WiFiMgrClass::setAPMode()
 {
-  IPAddress apIP(192, 168, 1, 1);
+  IPAddress apIP(192, 168, 4, 1);
   IPAddress apNetMsk(255, 255, 255, 0);
 
+  WiFi.setAutoReconnect(false);
   WiFi.mode(WIFI_AP);
   WiFi.softAPConfig(apIP, apIP, apNetMsk);
 
   Serial.println("Setting AP mode");
 
-  if (_APkey.length() == 0)
+  if (_APkey.length() < 8)
     WiFi.softAP(_APssid);
   else
     WiFi.softAP(_APssid, _APkey);
@@ -111,9 +113,6 @@ bool WiFiMgrClass::handle()
       return false;
 
     Serial.println("WiFi Connected");
-
-    if (!_STADHCP)
-      WiFi.config(_STAIPip, _STAIPgw, _STAIPmask, _STAIPdns);
 
     Serial.print("WiFi IP : ");
     Serial.println(WiFi.localIP());

--- a/WiFiMgr.h
+++ b/WiFiMgr.h
@@ -19,9 +19,9 @@ public:
   void setSTAIPdhcp(bool dhcp);
   void setSTAIPip(IPAddress ip, IPAddress gw, IPAddress mask, IPAddress dns);
 
-  void setAPssid(String ssid, String key = "");
+  void setAPssid(String ssid, String key);
 
-  void tryToConnect(String ssid, String key, String devicename);
+  void tryToConnect(const String& ssid, const String& key, const String& devicename);
   bool handle();
 
 protected:
@@ -29,12 +29,12 @@ private:
   String _STAssid;
   String _STAkey;
   String _devicename;
-  unsigned int _STAlastTry;
-  unsigned int _STAtryTimeout;
+  unsigned long _STAlastTry;
+  unsigned long _STAtryTimeout;
   String _APssid;
   String _APkey;
-  unsigned int _APlastTry;
-  unsigned int _APtryTimeout;
+  unsigned long _APlastTry;
+  unsigned long _APtryTimeout;
   bool _STAconnected;
   IPAddress _STAIPip;
   IPAddress _STAIPgw;

--- a/global.h
+++ b/global.h
@@ -240,6 +240,7 @@ boolean ReadConfig(){
     _config.color[3] = EEPROM.read(389); // W
     _config.mode = EEPROM.read(390);
     _config.animation = EEPROM.read(391);
+    if (_config.animation > 12) _config.animation = 0;
     _config.colorRandom = EEPROM.read(392);
     _config.brightnessAutoMinDay = EEPROM.read(393);
     _config.brightnessAutoMinNight = EEPROM.read(394);

--- a/global.h
+++ b/global.h
@@ -1,6 +1,8 @@
 #ifndef GLOBAL_H
 #define GLOBAL_H
 
+#define AP_DEFAULT_PASSWORD "TexTime-Setup"
+#define EEPROM_SIZE 1024
 
 ESP8266HTTPUpdateServer _httpUpdater;
 ESP8266WebServer _server(80);
@@ -34,12 +36,20 @@ struct strConfig {
   byte ledConfig;                       // 1 Byte - EEPROM 395
   byte luxSensitivity;                  // 1 Byte - EEPROM 396
   byte language;                        // 1 Byte - EEPROM 397
+  byte brightnessMax;                   // 1 Byte - EEPROM 398  
+
 
   String MQTTServer;                    // up to 64 Byte - EEPROM 512
   String MQTTLogin;                     // up to 64 Byte - EEPROM 576
   String MQTTPassword;                  // up to 64 Byte - EEPROM 640
   long MQTTPort;                        // 4 Byte - EEPROM 704
   long MQTTPubInterval;                 // 4 Byte - EEPROM 708
+
+  String APPassword;                    // up to 64 Byte - EEPROM 712
+
+  byte animSpeed;          // 1 Byte - EEPROM 776  (1-20, 10=normal)
+  byte animBrightnessMin;  // 1 Byte - EEPROM 777  (0-100 percent)
+  byte animBrightnessMax;  // 1 Byte - EEPROM 778  (0-100 percent)
 
 } _config;
 
@@ -72,20 +82,15 @@ long EEPROMReadlong(long address){
 
 // Check the Values is between 0-255
 boolean checkRange(String Value){
-  if (Value.toInt() < 0 || Value.toInt() > 255)
-  {
-    return false;
-  }
-  else
-  {
-    return true;
-  }
+  int v = Value.toInt();
+  return (v >= 0 && v <= 255);
 }
 
-void WriteStringToEEPROM(int beginaddress, String string){
-  char  charBuf[string.length() + 1];
-  string.toCharArray(charBuf, string.length() + 1);
-  for (unsigned int t =  0; t < sizeof(charBuf); t++)
+void WriteStringToEEPROM(int beginaddress, String string, int maxLen = 63){
+  if ((int)string.length() > maxLen) string = string.substring(0, maxLen);
+  char  charBuf[64];
+  string.toCharArray(charBuf, sizeof(charBuf));
+  for (unsigned int t = 0; t < sizeof(charBuf); t++)
   {
     EEPROM.write(beginaddress + t, charBuf[t]);
   }
@@ -101,12 +106,11 @@ String  ReadStringFromEEPROM(int beginaddress){
 
   while (1)
   {
+    if (counter >= 64) break;
     rChar = EEPROM.read(beginaddress + counter);
     if (rChar == 0) break;
-    if (counter > 63) break;
     counter++;
     retString.concat(rChar);
-
   }
   return retString;
 }
@@ -120,7 +124,7 @@ String  ReadStringFromEEPROM(int beginaddress){
 
 void ResetEEPROM()
 {
-  for (int i = 0; i < 511; i++)
+  for (int i = 0; i < EEPROM_SIZE; i++)
     EEPROM.write(i, 0xFF);
 
   EEPROM.commit();
@@ -179,12 +183,19 @@ void WriteConfig(){
   EEPROM.write(395, _config.ledConfig);
   EEPROM.write(396, _config.luxSensitivity);
   EEPROM.write(397, _config.language);
+  EEPROM.write(398, _config.brightnessMax);  
 
   WriteStringToEEPROM(512, _config.MQTTServer);
   WriteStringToEEPROM(576, _config.MQTTLogin);
   WriteStringToEEPROM(640, _config.MQTTPassword);
   EEPROMWritelong(704, _config.MQTTPort);
   EEPROMWritelong(708, _config.MQTTPubInterval);
+
+  WriteStringToEEPROM(712, _config.APPassword);
+
+  EEPROM.write(776, _config.animSpeed);
+  EEPROM.write(777, _config.animBrightnessMin);
+  EEPROM.write(778, _config.animBrightnessMax);
 
   EEPROM.commit();
 }
@@ -198,6 +209,7 @@ boolean ReadConfig(){
     _config.isDayLightSaving = EEPROM.read(17);
     _config.Update_Time_Via_NTP_Every = EEPROMReadlong(18); // 4 Byte
     _config.timeZone = EEPROMReadlong(22); // 4 Byte
+    if (_config.timeZone < -120 || _config.timeZone > 130) _config.timeZone = 10; // sanity check (unit = 1/10th hour)
     _config.IP[0] = EEPROM.read(32);
     _config.IP[1] = EEPROM.read(33);
     _config.IP[2] = EEPROM.read(34);
@@ -231,6 +243,7 @@ boolean ReadConfig(){
     _config.colorRandom = EEPROM.read(392);
     _config.brightnessAutoMinDay = EEPROM.read(393);
     _config.brightnessAutoMinNight = EEPROM.read(394);
+    _config.brightnessMax = EEPROM.read(398);
     _config.ledConfig = EEPROM.read(395);
     _config.luxSensitivity = EEPROM.read(396);
     _config.language = EEPROM.read(397);
@@ -240,6 +253,16 @@ boolean ReadConfig(){
     _config.MQTTPassword = ReadStringFromEEPROM(640);
     _config.MQTTPort = EEPROMReadlong(704);
     _config.MQTTPubInterval = EEPROMReadlong(708);
+
+    _config.APPassword = ReadStringFromEEPROM(712);
+    if (_config.APPassword.length() < 8) _config.APPassword = AP_DEFAULT_PASSWORD;
+
+    _config.animSpeed = EEPROM.read(776);
+    if (_config.animSpeed < 1 || _config.animSpeed > 20) _config.animSpeed = 10;
+    _config.animBrightnessMin = EEPROM.read(777);
+    if (_config.animBrightnessMin > 100) _config.animBrightnessMin = 10;
+    _config.animBrightnessMax = EEPROM.read(778);
+    if (_config.animBrightnessMax > 100 || _config.animBrightnessMax <= _config.animBrightnessMin) _config.animBrightnessMax = 100;
 
     return true;
 
@@ -270,7 +293,7 @@ void printConfig(){
 
  
   Serial.printf("SSID:%s\n", _config.ssid.c_str());
-  Serial.printf("PWD:%s\n", _config.password.c_str());
+  Serial.printf("PWD:***\n");
   Serial.printf("NTP ServerName:%s\n", _config.ntpServerName.c_str());
   Serial.printf("Device Name:%s\n", _config.DeviceName.c_str());
 
@@ -283,6 +306,7 @@ void printConfig(){
   Serial.printf("Color Random:%d\n", _config.colorRandom);
   Serial.printf("Minimum brightness auto during the day:%d\n", _config.brightnessAutoMinDay);
   Serial.printf("Minimum brightness auto during the night:%d\n", _config.brightnessAutoMinNight);
+  Serial.printf("Max brightness:%d\n", _config.brightnessMax);
   Serial.printf("Led Configuration:%d\n", _config.ledConfig);
 }
 


### PR DESCRIPTION
  ---
  ### 🇬🇧 English

  ## New features

  Tetris & Snake games (web interface)

  - Page_tetris.h — Tetris playable from any browser hosted on the ESP8266.
    Supports touch controls on smartphone/tablet screens, and Bluetooth game
    controllers (PS4, PS5, Xbox, etc.) connected to the visiting device.
    Score/level/lines display, next-piece preview, runs on the LED matrix
  - Page_snake.h — Snake playable from any browser hosted on the ESP8266.
    Same dual control support: touchscreen or Bluetooth gamepad.
    Runs on the LED matrix
  - Accessible via /tetris.html and /snake.html
  - Links added in the sidebar navigation of the dashboard

  5 new animations + improvements to existing ones (LedStrip.h)

  Animation controls in the dashboard (Page_index.h)

  - Animation speed slider (1–20)
  - Animation min brightness slider (0–100%)
  - Animation max brightness slider (0–100%)

  Custom inline color picker (Page_index.h)

  - Replaces native `<input type="color">` which showed broken HSV sliders (defaulting to 0,0,0) in Android Chrome's "Personnalisé" mode
  - Click the color swatch to open an inline picker: 2D saturation/brightness square + hue rainbow slider
  - Works identically on all browsers and platforms (Android, iOS, desktop)
  - Hex text input retained for direct entry


  ## Bug fixes

  global.h

  - ResetEEPROM: only erased 511 bytes — MQTT zone was never cleared. Now uses EEPROM_SIZE (1024)
  - ReadStringFromEEPROM: off-by-one error corrected (read past buffer end)
  - WriteStringToEEPROM: added maxLen parameter with truncation to prevent overflow
  - printConfig: passwords now masked (***) in Serial output
  - Added AP_DEFAULT_PASSWORD and EEPROM_SIZE constants
  - Added APPassword field (EEPROM 712), brightnessMax, and animSpeed/Min/Max fields
  - Added sanity check on timeZone in ReadConfig
  - Animation index now bounds-checked on read — prevents silent fallback to Normal mode on first boot when EEPROM contains an out-of-range value

  LedStrip.h

  - Matrix animation: trail fade used absolute Darken(35) — tail disappeared completely at low animBrightnessMax values. Fixed with proportional fade (brightness scales linearly with distance from head)
  - Lightning animation: FLASH phase set all pixels to white without calling copyForeground(), briefly erasing the time words. Fixed by adding copyForeground() at the end of the FLASH case

  WiFiMgr.h

  - Timers unsigned int → unsigned long — overflow caused AP fallback failure after ~65s

  WiFiMgr.cpp

  - Static IP now applied before WiFi.begin() (was after — caused DHCP conflict)
  - WiFi password removed from Serial logs
  - AP address corrected: 192.168.1.1 → 192.168.4.1 (standard ESP8266 AP address)
  - Added WiFi.setAutoReconnect(false) before switching to AP mode (two conflicting mechanisms)
  - STA timeout increased: 10s → 30s (WiFi 6 routers are slower to associate)
  - AP key validation: length() == 0 → length() < 8 (WPA2 requires minimum 8 characters)

  NTP.h

  - Integer overflow fix in timezone calculation: timeZone * 360 could overflow int for UTC+9 and above (32767 limit). Fixed with (long) cast: (long)timeZone * 360. The select uses 1/10th-hour units (GMT+1 =
  value 10, 10 × 360s = 3600s = 1h), so the multiplier 360 is correct and unchanged

  TexTime.ino

  - Use EEPROM_SIZE constant instead of hardcoded 1024
  - Default config now initializes all new fields and calls WriteConfig()
  - setAPssid now passes APPassword
  - tryToConnect uses const String& (avoids unnecessary heap copies)
  - setTimeout cast to unsigned long to prevent overflow
  - Added routes for Tetris and Snake

  Page_network.h

  - Passwords (WiFi + AP) no longer sent back to the browser on page load
  - APPassword field added: only saved if length ≥ 8 (WPA2 requirement)

  Page_general.h

  - send_general_configuration_values_html: exposes animSpeed, animBrightnessMin, animBrightnessMax
  - send_general_led: live update of animation parameters without page reload; animation speed now calls setAnimSpeed() so the frame rate changes immediately (no Save required)


  ---


  ### 🇫🇷 Français

  ## Nouvelles fonctionnalités

  Jeux Tetris & Snake (interface web)

  - Page_tetris.h — Tetris jouable depuis n'importe quel navigateur connecté
    à l'ESP8266. Contrôles tactiles sur écran de smartphone/tablette, ou via
    un contrôleur Bluetooth (PS4, PS5, Xbox, etc.) connecté à l'appareil visitant
    la page. Affichage score/niveau/lignes, aperçu de la pièce suivante,
    s'exécute sur la matrice LED
  - Page_snake.h — Snake jouable depuis n'importe quel navigateur connecté
    à l'ESP8266. Même double support : écran tactile ou manette Bluetooth.
    S'exécute sur la matrice LED
  - Accessible via /tetris.html et /snake.html
  - Liens ajoutés dans la navigation latérale du dashboard

  5 nouvelles animations + améliorations des animations existantes (LedStrip.h)

  Contrôles d'animation dans le dashboard (Page_index.h)

  - Slider de vitesse d'animation (1–20)
  - Slider de luminosité minimale des animations (0–100%)
  - Slider de luminosité maximale des animations (0–100%)

  Sélecteur de couleur inline personnalisé (Page_index.h)

  - Remplace le `<input type="color">` natif dont les sliders HSV affichaient 0,0,0 (noir) par défaut dans le mode « Personnalisé » d'Android Chrome
  - Cliquer sur le carré coloré ouvre un picker inline : carré saturation/luminosité 2D + slider teinte arc-en-ciel
  - Fonctionne à l'identique sur tous les navigateurs et plateformes (Android, iOS, desktop)
  - Champ texte hex conservé pour la saisie directe


  ## Corrections de bugs

  global.h

  - ResetEEPROM : n'effaçait que 511 octets — la zone MQTT n'était jamais effacée. Utilise maintenant EEPROM_SIZE (1024)
  - ReadStringFromEEPROM : débordement d'un octet corrigé (lecture au-delà du buffer)
  - WriteStringToEEPROM : ajout d'un paramètre maxLen avec troncature pour éviter les débordements
  - printConfig : les mots de passe sont maintenant masqués (***) dans la sortie Serial
  - Ajout des constantes AP_DEFAULT_PASSWORD et EEPROM_SIZE
  - Ajout des champs APPassword (EEPROM 712), brightnessMax, et animSpeed/Min/Max
  - Ajout d'une vérification de cohérence sur timeZone dans ReadConfig
  - Index d'animation borné à la lecture — évite un fallback silencieux vers le mode Normal au démarrage si l'EEPROM contient une valeur hors plage

  LedStrip.h

  - Animation Matrix : le fondu de la traînée utilisait Darken(35) absolu — la queue disparaissait complètement pour les faibles valeurs d'animBrightnessMax. Corrigé avec un fondu proportionnel (luminosité
  décroît linéairement avec la distance à la tête)
  - Animation Lightning : la phase FLASH mettait tous les pixels en blanc sans appeler copyForeground(), effaçant brièvement les mots de l'heure. Corrigé par l'ajout de copyForeground() en fin de case FLASH

  WiFiMgr.h

  - Timers unsigned int → unsigned long — l'overflow provoquait un échec du basculement en mode AP après ~65s

  WiFiMgr.cpp

  - L'IP statique est maintenant appliquée avant WiFi.begin() (était après — conflit DHCP)
  - Le mot de passe WiFi supprimé des logs Serial
  - Adresse AP corrigée : 192.168.1.1 → 192.168.4.1 (adresse standard ESP8266 en mode AP)
  - Ajout de WiFi.setAutoReconnect(false) avant le passage en mode AP (deux mécanismes en conflit)
  - Timeout STA augmenté : 10s → 30s (les box WiFi 6 sont plus lentes à associer)
  - Validation de la clé AP : length() == 0 → length() < 8 (WPA2 exige 8 caractères minimum)

  NTP.h

  - Correction d'un overflow entier dans le calcul du fuseau horaire : timeZone * 360 dépassait la limite int (32767) pour UTC+9 et au-delà. Corrigé avec un cast (long) : (long)timeZone * 360. Le select
  utilise des unités de 1/10ème d'heure (GMT+1 = valeur 10, 10 × 360s = 3600s = 1h), le multiplicateur 360 est donc correct et inchangé

  TexTime.ino

  - Utilisation de la constante EEPROM_SIZE au lieu de 1024 en dur
  - La config par défaut initialise maintenant tous les nouveaux champs et appelle WriteConfig()
  - setAPssid transmet maintenant APPassword
  - tryToConnect utilise const String& (évite les copies inutiles sur le heap)
  - Cast unsigned long sur setTimeout pour éviter l'overflow
  - Ajout des routes pour Tetris et Snake

  Page_network.h

  - Les mots de passe (WiFi + AP) ne sont plus renvoyés au navigateur à l'ouverture de la page
  - Champ APPassword ajouté : sauvegardé uniquement si longueur ≥ 8 (exigence WPA2)

  Page_general.h

  - send_general_configuration_values_html : expose animSpeed, animBrightnessMin, animBrightnessMax
  - send_general_led : mise à jour live des paramètres d'animation sans rechargement de page ; la vitesse d'animation appelle maintenant setAnimSpeed() pour que la fréquence change immédiatement (sans
  nécessiter Save)