### PR TITLE
Feat: weekly display scheduler (mode/animation per half-hour)

### DIFF
--- a/Page_index.h
+++ b/Page_index.h
@@ -43,6 +43,10 @@ const char PAGE_index[] PROGMEM = R"=====(
           <span class="nav-icon">🔄</span>
           <span>Firmware Update</span>
         </button>
+        <button class="nav-item" data-section="scheduler">
+          <span class="nav-icon">&#x23F0;</span>
+          <span>Scheduler</span>
+        </button>
       </div>
     </nav>
 
@@ -430,6 +434,75 @@ const char PAGE_index[] PROGMEM = R"=====(
           </div>
         </section>
 
+        <!-- Scheduler Section -->
+        <section id="scheduler-section" class="content-section">
+          <div class="dashboard-grid">
+            <div class="card">
+              <div class="card-title">Weekly Schedule</div>
+              <div class="form-group">
+                <div class="checkbox-group">
+                  <input type="checkbox" id="schedulerEnabled" class="checkbox" onchange="saveSchedulerEnabled()">
+                  <label for="schedulerEnabled" class="form-label">Enable scheduler (applies each half-hour, overrides general settings)</label>
+                </div>
+              </div>
+              <p style="font-size:0.8rem;color:var(--text-secondary);margin-bottom:0.75rem">Select a rule on the right, then click/drag cells to paint them. Click a painted cell again to erase it.</p>
+              <div id="schedGrid" class="sched-grid-wrap"><div class="loading">Loading...</div></div>
+            </div>
+            <div class="card sched-editor">
+              <div class="card-title">Rules</div>
+              <div id="schedRulesList" style="margin-bottom:0.4rem"></div>
+              <button class="btn btn-secondary btn-block" onclick="schedAddRule()" style="margin-bottom:0.4rem">+ New rule</button>
+              <hr style="border:none;border-top:1px solid var(--border);margin-bottom:0.4rem">
+              <div class="form-group">
+                <label class="form-label">Display mode</label>
+                <select id="schedMode" class="form-control" onchange="schedEditorChange()"></select>
+              </div>
+              <div class="form-group">
+                <label class="form-label">Color</label>
+                <input type="color" id="schedColor" value="#ffffff" class="form-control" style="height:2rem;padding:0.1rem;cursor:pointer" onchange="schedEditorChange()">
+              </div>
+              <div class="form-group">
+                <label class="form-label">Color randomization</label>
+                <select id="schedColorRandom" class="form-control" onchange="schedEditorChange()">
+                  <option value="0">No Random</option>
+                  <option value="1">Random all</option>
+                  <option value="2">Random letter</option>
+                  <option value="3">Random word</option>
+                </select>
+              </div>
+              <div class="form-group">
+                <label class="form-label">Animation</label>
+                <select id="schedAnimation" class="form-control" onchange="schedEditorChange()"></select>
+              </div>
+              <div class="form-group">
+                <label class="form-label">Speed (1=slow, 20=fast)</label>
+                <div class="range-group">
+                  <input type="range" id="schedAnimSpeed" class="range-input" min="1" max="20" step="1" oninput="document.getElementById('schedAnimSpeedT').textContent=this.value;schedEditorChange()">
+                  <div class="range-value" id="schedAnimSpeedT">10</div>
+                </div>
+              </div>
+              <div class="form-group">
+                <label class="form-label">Min brightness (%)</label>
+                <div class="range-group">
+                  <input type="range" id="schedAnimBrightMin" class="range-input" min="0" max="100" step="1" oninput="document.getElementById('schedAnimBrightMinT').textContent=this.value;schedEditorChange()">
+                  <div class="range-value" id="schedAnimBrightMinT">10</div>
+                </div>
+              </div>
+              <div class="form-group">
+                <label class="form-label">Max brightness (%)</label>
+                <div class="range-group">
+                  <input type="range" id="schedAnimBrightMax" class="range-input" min="0" max="100" step="1" oninput="document.getElementById('schedAnimBrightMaxT').textContent=this.value;schedEditorChange()">
+                  <div class="range-value" id="schedAnimBrightMaxT">100</div>
+                </div>
+              </div>
+              <div style="display:flex;gap:0.5rem;margin-top:0.5rem">
+                <button class="btn btn-secondary" onclick="schedRaz()" style="flex:1">RAZ</button>
+                <button class="btn btn-primary" id="schedSaveBtn" onclick="saveAllScheduler()" style="flex:2">Save</button>
+              </div>
+            </div>
+          </div>
+        </section>
+
         <!-- Update Section -->
         <section id="update-section" class="content-section">
           <div class="dashboard-grid">
@@ -516,7 +589,8 @@ const char PAGE_index[] PROGMEM = R"=====(
       'network': 'Network Configuration',
       'ntp': 'Time Configuration',
       'mqtt': 'MQTT Configuration',
-      'update': 'Firmware Update'
+      'update': 'Firmware Update',
+      'scheduler': 'Display Scheduler'
     };
 
     // Utility functions
@@ -638,6 +712,9 @@ const char PAGE_index[] PROGMEM = R"=====(
           break;
         case 'mqtt':
           loadMqttSettings();
+          break;
+        case 'scheduler':
+          loadSchedulerSettings();
           break;
       }
     }
@@ -1198,6 +1275,267 @@ const char PAGE_index[] PROGMEM = R"=====(
         closeMobileMenu();
       }
     });
+
+    // ── Scheduler ──────────────────────────────────────────────────────────────
+    function toHex2(v){var h=Math.round(v).toString(16);return h.length<2?'0'+h:h;}
+    function schedTextColor(r,g,b){return (r*299+g*587+b*114)/1000>128?'#111':'#fff';}
+    var schedCells=new Array(336).fill(null);
+    var schedRules=[];
+    var schedCurrentRule=0;
+    var schedModeNames=[],schedAnimNames=[];
+    var schedDragging=false,schedDragMode=null;
+
+    function schedEditorChange() {
+      if(!schedRules.length) return;
+      var r=schedRules[schedCurrentRule];
+      r.mode=parseInt(document.getElementById('schedMode').value);
+      r.anim=parseInt(document.getElementById('schedAnimation').value);
+      r.colorRandom=parseInt(document.getElementById('schedColorRandom').value);
+      r.animSpeed=parseInt(document.getElementById('schedAnimSpeed').value);
+      r.animBrightMin=parseInt(document.getElementById('schedAnimBrightMin').value);
+      r.animBrightMax=parseInt(document.getElementById('schedAnimBrightMax').value);
+      var ch=document.getElementById('schedColor').value.replace('#','');
+      r.r=parseInt(ch.substr(0,2),16)||0;
+      r.g=parseInt(ch.substr(2,2),16)||0;
+      r.b=parseInt(ch.substr(4,2),16)||0;
+      schedRenderRulesList();
+      var hex='#'+toHex2(r.r)+toHex2(r.g)+toHex2(r.b);
+      var tc=schedTextColor(r.r,r.g,r.b);
+      document.querySelectorAll('#schedGrid .sched-half.sched-cur').forEach(function(el){
+        el.style.background=hex; el.style.color=tc;
+      });
+    }
+
+    function schedLoadEditor(rule) {
+      document.getElementById('schedMode').value=rule.mode;
+      document.getElementById('schedColorRandom').value=rule.colorRandom;
+      document.getElementById('schedAnimation').value=rule.anim;
+      document.getElementById('schedAnimSpeed').value=rule.animSpeed;
+      document.getElementById('schedAnimSpeedT').textContent=rule.animSpeed;
+      document.getElementById('schedAnimBrightMin').value=rule.animBrightMin;
+      document.getElementById('schedAnimBrightMinT').textContent=rule.animBrightMin;
+      document.getElementById('schedAnimBrightMax').value=rule.animBrightMax;
+      document.getElementById('schedAnimBrightMaxT').textContent=rule.animBrightMax;
+      document.getElementById('schedColor').value='#'+toHex2(rule.r)+toHex2(rule.g)+toHex2(rule.b);
+    }
+
+    function schedRenderRulesList() {
+      var el=document.getElementById('schedRulesList');
+      var crNames=['no random','rnd all','rnd letter','rnd word'];
+      var html='';
+      schedRules.forEach(function(rule,i){
+        var ledHex='#'+toHex2(rule.r)+toHex2(rule.g)+toHex2(rule.b);
+        var mname=schedModeNames[rule.mode]||'mode '+rule.mode;
+        var crname=crNames[rule.colorRandom]||'';
+        var aname=schedAnimNames[rule.anim]||'anim '+rule.anim;
+        var label=mname+' - '+crname+' - '+aname;
+        var active=i===schedCurrentRule;
+        html+='<div class="sched-rule-item'+(active?' sched-rule-active':'')+'" onclick="schedSelectRule('+i+')">'
+          +'<div class="sched-rule-num">'+(i+1)+'</div>'
+          +'<div style="flex:1;font-size:0.8rem">'+label+'</div>'
+          +'<div class="sched-rule-led" style="background:'+ledHex+'" title="LED color"></div>'
+          +'<button class="sched-rule-del" onclick="event.stopPropagation();schedDelRule('+i+')" title="Delete">&#x2715;</button>'
+          +'</div>';
+      });
+      el.innerHTML=html;
+    }
+
+    function schedSelectRule(idx) {
+      schedCurrentRule=idx;
+      schedLoadEditor(schedRules[idx]);
+      schedRenderRulesList();
+      renderSchedulerGrid();
+    }
+
+    function schedAddRule() {
+      schedRules.push({mode:0,anim:0,colorRandom:0,animSpeed:10,animBrightMin:10,animBrightMax:100,r:0,g:0,b:0});
+      schedSelectRule(schedRules.length-1);
+    }
+
+    function schedDelRule(idx) {
+      if(schedRules.length<=1) return;
+      schedRules.splice(idx,1);
+      for(var i=0;i<336;i++){
+        if(schedCells[i]===idx) schedCells[i]=null;
+        else if(schedCells[i]>idx) schedCells[i]--;
+      }
+      if(schedCurrentRule>=schedRules.length) schedCurrentRule=schedRules.length-1;
+      schedLoadEditor(schedRules[schedCurrentRule]);
+      schedRenderRulesList();
+      renderSchedulerGrid();
+    }
+
+    function renderSchedulerGrid() {
+      var days=['Mon','Tue','Wed','Thu','Fri','Sat','Sun'];
+      var html='<table class="sched-table"><thead><tr><th></th>';
+      days.forEach(function(d){html+='<th>'+d+'</th>';});
+      html+='</tr></thead><tbody>';
+      for(var h=0;h<24;h++){
+        html+='<tr><td class="sched-hour">'+(h<10?'0':'')+h+'h</td>';
+        for(var d=0;d<7;d++){
+          html+='<td class="sched-cell">';
+          for(var m=0;m<2;m++){
+            var idx=d*48+h*2+m;
+            var ri=schedCells[idx];
+            var style='',label='';
+            if(ri!==null&&ri!==undefined){
+              var rr=schedRules[ri];
+              style='background:#'+toHex2(rr.r)+toHex2(rr.g)+toHex2(rr.b)+';color:'+schedTextColor(rr.r,rr.g,rr.b)+';';
+              label=String(ri+1);
+            }
+            var isCur=(ri===schedCurrentRule)?'sched-cur':'';
+            html+='<div class="sched-half '+isCur+'" data-d="'+d+'" data-h="'+h+'" data-m="'+(m*30)+'" style="'+style+'">'+label+'</div>';
+          }
+          html+='</td>';
+        }
+        html+='</tr>';
+      }
+      html+='</tbody></table>';
+      document.getElementById('schedGrid').innerHTML=html;
+      schedInitGridEvents();
+    }
+
+    function schedCellAt(el) {
+      var c=el&&el.closest?el.closest('[data-d]'):null;
+      if(!c||!c.classList.contains('sched-half')) return null;
+      var d=parseInt(c.dataset.d),h=parseInt(c.dataset.h),m=parseInt(c.dataset.m);
+      return {el:c,idx:d*48+h*2+(m>=30?1:0)};
+    }
+
+    function schedPaintEl(info) {
+      var ri=schedCells[info.idx];
+      if(ri!==null&&ri!==undefined){
+        var rr=schedRules[ri];
+        info.el.style.background='#'+toHex2(rr.r)+toHex2(rr.g)+toHex2(rr.b);
+        info.el.style.color=schedTextColor(rr.r,rr.g,rr.b);
+        info.el.textContent=String(ri+1);
+        info.el.className='sched-half'+(ri===schedCurrentRule?' sched-cur':'');
+      } else {
+        info.el.style.cssText='';
+        info.el.textContent='';
+        info.el.className='sched-half';
+      }
+    }
+
+    function schedInitGridEvents() {
+      var grid=document.getElementById('schedGrid');
+      if(!grid||grid._ei) return;
+      grid._ei=true;
+      function ptInfo(x,y){return schedCellAt(document.elementFromPoint(x,y));}
+      function onStart(x,y){
+        var info=ptInfo(x,y); if(!info) return;
+        schedDragging=true;
+        schedDragMode=(schedCells[info.idx]===schedCurrentRule)?'remove':'add';
+        schedCells[info.idx]=schedDragMode==='add'?schedCurrentRule:null;
+        schedPaintEl(info);
+      }
+      function onMove(x,y){
+        if(!schedDragging) return;
+        var info=ptInfo(x,y); if(!info) return;
+        if(schedDragMode==='add'&&schedCells[info.idx]!==schedCurrentRule){
+          schedCells[info.idx]=schedCurrentRule; schedPaintEl(info);
+        } else if(schedDragMode==='remove'&&schedCells[info.idx]!==null){
+          schedCells[info.idx]=null; schedPaintEl(info);
+        }
+      }
+      function onEnd(){schedDragging=false;schedDragMode=null;}
+      grid.addEventListener('mousedown',function(e){onStart(e.clientX,e.clientY);e.preventDefault();});
+      document.addEventListener('mousemove',function(e){onMove(e.clientX,e.clientY);});
+      document.addEventListener('mouseup',onEnd);
+      grid.addEventListener('touchstart',function(e){onStart(e.touches[0].clientX,e.touches[0].clientY);e.preventDefault();},{passive:false});
+      document.addEventListener('touchmove',function(e){if(schedDragging){onMove(e.touches[0].clientX,e.touches[0].clientY);e.preventDefault();}},{passive:false});
+      document.addEventListener('touchend',onEnd);
+    }
+
+    function schedRaz() {
+      if(!confirm('Clear all scheduled slots?')) return;
+      schedCells=new Array(336).fill(null);
+      renderSchedulerGrid();
+    }
+
+    function loadSchedulerSettings() {
+      setValues('/admin/schedulerconfig')
+        .then(function(){
+          return fetch('/admin/generalmodesvalues').then(function(r){return r.text();}).then(function(txt){
+            schedModeNames=[];
+            txt.split('\n').forEach(function(l){var p=l.split('|');if(p.length>=2&&p[1])schedModeNames.push(p[1]);});
+          });
+        })
+        .then(function(){
+          return fetch('/admin/generalanimationsvalues').then(function(r){return r.text();}).then(function(txt){
+            schedAnimNames=[];
+            txt.split('\n').forEach(function(l){var p=l.split('|');if(p.length>=2&&p[1])schedAnimNames.push(p[1]);});
+            var ms=document.getElementById('schedMode');ms.innerHTML='';
+            schedModeNames.forEach(function(n,i){var o=document.createElement('option');o.value=i;o.textContent=n;ms.appendChild(o);});
+            var as=document.getElementById('schedAnimation');as.innerHTML='';
+            schedAnimNames.forEach(function(n,i){var o=document.createElement('option');o.value=i;o.textContent=n;as.appendChild(o);});
+          });
+        })
+        .then(function(){
+          return fetch('/admin/schedulerdata').then(function(r){return r.text();}).then(function(txt){
+            schedCells=new Array(336).fill(null);
+            schedRules=[];
+            var ruleMap={};
+            for(var i=0;i<336;i++){
+              var hex=txt.substr(i*16,16);
+              if(hex.length<16) continue;
+              var b0=parseInt(hex.substr(0,2),16);
+              if(b0===0xFF) continue;
+              var key=hex;
+              if(ruleMap[key]===undefined){
+                var b1=parseInt(hex.substr(2,2),16);
+                var b2=parseInt(hex.substr(4,2),16);
+                ruleMap[key]=schedRules.length;
+                schedRules.push({
+                  mode:b0,anim:b1,
+                  colorRandom:b2&0x03,animSpeed:((b2>>2)&0x1F)+1,
+                  animBrightMin:parseInt(hex.substr(6,2),16),
+                  animBrightMax:parseInt(hex.substr(8,2),16),
+                  r:parseInt(hex.substr(10,2),16),
+                  g:parseInt(hex.substr(12,2),16),
+                  b:parseInt(hex.substr(14,2),16)
+                });
+              }
+              schedCells[i]=ruleMap[key];
+            }
+            if(!schedRules.length) schedRules.push({mode:1,anim:0,colorRandom:0,animSpeed:10,animBrightMin:10,animBrightMax:100,r:255,g:255,b:255});
+            schedCurrentRule=0;
+            schedLoadEditor(schedRules[0]);
+            schedRenderRulesList();
+            renderSchedulerGrid();
+          });
+        });
+    }
+
+    function saveSchedulerEnabled() {
+      var en=document.getElementById('schedulerEnabled').checked?'1':'0';
+      fetch('/admin/save/schedulerenabled',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:'enabled='+en});
+    }
+
+    async function saveAllScheduler() {
+      var btn=document.getElementById('schedSaveBtn');
+      setSaveButtonState(btn,'saving');
+      try {
+        var hex='';
+        for(var i=0;i<336;i++){
+          var ri=schedCells[i];
+          if(ri===null||ri===undefined){
+            hex+='FFFFFFFFFFFFFFFF';
+          } else {
+            var rule=schedRules[ri];
+            var packed=(rule.colorRandom&0x03)|((rule.animSpeed-1)<<2);
+            hex+=toHex2(rule.mode)+toHex2(rule.anim)+toHex2(packed)
+                +toHex2(rule.animBrightMin)+toHex2(rule.animBrightMax)
+                +toHex2(rule.r)+toHex2(rule.g)+toHex2(rule.b);
+          }
+        }
+        await fetch('/admin/save/schedulerbulk',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:'data='+hex});
+        await fetch('/admin/scheduler/apply',{method:'POST'});
+        setSaveButtonState(btn,'success');
+      } catch(e){setSaveButtonState(btn,'error');}
+    }
+    // ── End Scheduler ──────────────────────────────────────────────────────────
+
   </script>
 </body>
 </html>

--- a/Page_scheduler.h
+++ b/Page_scheduler.h
@@ -1,0 +1,170 @@
+
+// Slot layout in EEPROM (8 bytes per slot):
+//   [0] mode (0xFF = slot disabled)
+//   [1] animation
+//   [2] (colorRandom & 0x03) | ((animSpeed-1) << 2)
+//   [3] animBrightnessMin
+//   [4] animBrightnessMax
+//   [5] R  [6] G  [7] B
+//
+// 336 slots total: 7 days × 48 half-hours (slot = hour*2 + (min>=30?1:0))
+
+inline int schedAddr(byte day, byte slot) {  // slot 0..47
+  return SCHEDULER_EEPROM_BASE + 1 + (int(day) * 48 + slot) * SCHEDULER_SLOT_SIZE;
+}
+
+void send_scheduler_config() {
+  byte en = EEPROM.read(SCHEDULER_EEPROM_BASE);
+  String out = "schedulerEnabled|" + String(en == 1 ? "checked" : "") + "|chk\n";
+  _server.send(200, "text/plain", out);
+}
+
+void send_scheduler_data() {
+  _server.setContentLength(CONTENT_LENGTH_UNKNOWN);
+  _server.send(200, "text/plain", "");
+  char buf[17];
+  for (int day = 0; day < 7; day++) {
+    for (int slot = 0; slot < 48; slot++) {
+      int addr = schedAddr(day, slot);
+      for (int k = 0; k < SCHEDULER_SLOT_SIZE; k++)
+        sprintf(buf + k * 2, "%02X", EEPROM.read(addr + k));
+      buf[16] = 0;
+      _server.sendContent(buf);
+    }
+  }
+  _server.sendContent("");
+}
+
+void save_scheduler_slot() {
+  int day = -1, hour = -1, minute = 0;
+  byte mode = 0xFF, animation = 0, colorRandom = 0, animSpeed = 10;
+  byte animBrightnessMin = 10, animBrightnessMax = 100;
+  byte r = 255, g = 255, b = 255;
+  bool slotEnabled = false;
+
+  for (uint8_t i = 0; i < _server.args(); i++) {
+    String n = _server.argName(i);
+    String v = _server.arg(i);
+    if (n == "day")            day = v.toInt();
+    else if (n == "hour")      hour = v.toInt();
+    else if (n == "minute")    minute = v.toInt();
+    else if (n == "enabled")   slotEnabled = (v == "1");
+    else if (n == "mode")      mode = constrain(v.toInt(), 0, 7);
+    else if (n == "animation") animation = constrain(v.toInt(), 0, 12);
+    else if (n == "colorrandom")   colorRandom = constrain(v.toInt(), 0, 3);
+    else if (n == "animspeed")     animSpeed = constrain(v.toInt(), 1, 20);
+    else if (n == "animbrightmin") animBrightnessMin = constrain(v.toInt(), 0, 100);
+    else if (n == "animbrightmax") animBrightnessMax = constrain(v.toInt(), 0, 100);
+    else if (n == "color") {
+      String cs = v;
+      if (cs.startsWith("#")) cs = cs.substring(1);
+      int32_t l = strtol(cs.c_str(), 0, 16);
+      r = (l >> 16) & 0xFF;
+      g = (l >> 8) & 0xFF;
+      b = l & 0xFF;
+    }
+  }
+
+  if (day < 0 || day > 6 || hour < 0 || hour > 23) {
+    _server.send(400, "text/plain", "ERROR");
+    return;
+  }
+
+  int slot = hour * 2 + (minute >= 30 ? 1 : 0);
+  int addr = schedAddr(day, slot);
+  if (!slotEnabled) {
+    EEPROM.write(addr, 0xFF);
+  } else {
+    EEPROM.write(addr,     mode);
+    EEPROM.write(addr + 1, animation);
+    EEPROM.write(addr + 2, (colorRandom & 0x03) | ((animSpeed - 1) << 2));
+    EEPROM.write(addr + 3, animBrightnessMin);
+    EEPROM.write(addr + 4, animBrightnessMax);
+    EEPROM.write(addr + 5, r);
+    EEPROM.write(addr + 6, g);
+    EEPROM.write(addr + 7, b);
+  }
+  EEPROM.commit();
+  _server.send(200, "text/plain", "OK");
+}
+
+void save_scheduler_enabled() {
+  for (uint8_t i = 0; i < _server.args(); i++) {
+    if (_server.argName(i) == "enabled") {
+      EEPROM.write(SCHEDULER_EEPROM_BASE, _server.arg(i) == "1" ? 1 : 0);
+      EEPROM.commit();
+    }
+  }
+  _server.send(200, "text/plain", "OK");
+}
+
+void save_scheduler_raz() {
+  for (int i = 0; i < 336; i++)
+    EEPROM.write(SCHEDULER_EEPROM_BASE + 1 + i * SCHEDULER_SLOT_SIZE, 0xFF);
+  EEPROM.commit();
+  _server.send(200, "text/plain", "OK");
+}
+
+// Bulk save: body arg "data" = 336*16 hex chars representing all slots
+void save_scheduler_bulk() {
+  String data = _server.arg("data");
+  if (data.length() != 336 * 16) {
+    _server.send(400, "text/plain", "ERROR");
+    return;
+  }
+  char buf[3]; buf[2] = 0;
+  for (int i = 0; i < 336; i++) {
+    int addr = SCHEDULER_EEPROM_BASE + 1 + i * SCHEDULER_SLOT_SIZE;
+    for (int k = 0; k < SCHEDULER_SLOT_SIZE; k++) {
+      buf[0] = data[i * 16 + k * 2];
+      buf[1] = data[i * 16 + k * 2 + 1];
+      EEPROM.write(addr + k, (byte)strtol(buf, 0, 16));
+    }
+  }
+  EEPROM.commit();
+  _server.send(200, "text/plain", "OK");
+}
+
+byte _schedLastSlot = 255;
+byte _schedLastDay  = 255;
+
+void apply_scheduler_now() {
+  _schedLastSlot = 255;
+  _server.send(200, "text/plain", "OK");
+}
+
+// Called from loop() every iteration — runs at most once per half-hour (or immediately after apply_scheduler_now)
+void handleScheduler() {
+  if (EEPROM.read(SCHEDULER_EEPROM_BASE) != 1) return;
+
+  byte currentSlot = _dateTime.hour * 2 + (_dateTime.minute >= 30 ? 1 : 0);
+  // _dateTime.wday: 1=Sunday..7=Saturday → convert to 0=Mon..6=Sun
+  byte currentDay = (_dateTime.wday <= 1) ? 6 : (_dateTime.wday - 2);
+
+  if (currentSlot == _schedLastSlot && currentDay == _schedLastDay) return;
+  _schedLastSlot = currentSlot;
+  _schedLastDay  = currentDay;
+
+  int addr = schedAddr(currentDay, currentSlot);
+  byte mode = EEPROM.read(addr);
+  if (mode == 0xFF || mode > 7) return;
+
+  byte animation      = constrain(EEPROM.read(addr + 1), 0, 12);
+  byte packed         = EEPROM.read(addr + 2);
+  byte colorRandom    = packed & 0x03;
+  byte animSpeed      = constrain(((packed >> 2) & 0x1F) + 1, 1, 20);
+  byte animBrightMin  = constrain(EEPROM.read(addr + 3), 0, 100);
+  byte animBrightMax  = constrain(EEPROM.read(addr + 4), 0, 100);
+  byte cr = EEPROM.read(addr + 5);
+  byte cg = EEPROM.read(addr + 6);
+  byte cb = EEPROM.read(addr + 7);
+
+  _config.animBrightnessMin = animBrightMin;
+  _config.animBrightnessMax = animBrightMax;
+
+  QTLed.setMode(mode);
+  QTLed.setAnimation(animation);
+  QTLed.setColor(cr, cg, cb);
+  QTLed.setColorRandom((RandomColorMode)colorRandom);
+  QTLed.setAnimSpeed(animSpeed);
+}

--- a/Page_style.css.h
+++ b/Page_style.css.h
@@ -1038,5 +1038,38 @@ body {
     height: 10px;
   }
 }
+
+/* Scheduler editor card — compact overrides */
+.sched-editor { padding: 0.65rem !important; }
+.sched-editor .card-title { font-size: 0.95rem; margin-bottom: 0.35rem; }
+.sched-editor .form-group { margin-bottom: 0.3rem; }
+.sched-editor .form-label { font-size: 0.72rem; margin-bottom: 0.1rem; }
+.sched-editor .form-control { padding: 0.22rem 0.45rem; font-size: 0.78rem; }
+.sched-editor .range-group { gap: 0.3rem; }
+.sched-editor .range-input { height: 3px; }
+.sched-editor .range-value { font-size: 0.75rem; min-width: 1.8rem; }
+.sched-editor .sched-rule-item { padding: 0.25rem 0.5rem; margin-bottom: 0.2rem; }
+.sched-editor .sched-rule-num { min-width: 1rem; height: 1rem; font-size: 0.65rem; }
+.sched-editor .sched-rule-led { width: 0.85rem; height: 0.85rem; }
+.sched-editor .btn { padding: 0.28rem 0.6rem; font-size: 0.8rem; }
+
+/* Scheduler grid */
+.sched-grid-wrap { overflow-x: auto; margin-top: 0.5rem; user-select: none; -webkit-user-select: none; }
+.sched-table { border-collapse: collapse; width: 100%; font-size: 0.72rem; }
+.sched-table th { padding: 0.25rem 0.4rem; background: var(--surface); border: 1px solid var(--border); text-align: center; font-weight: 600; }
+.sched-hour { padding: 0.25rem 0.4rem; background: var(--surface); border: 1px solid var(--border); font-weight: 500; white-space: nowrap; font-size: 0.7rem; }
+.sched-cell { border: 1px solid var(--border); min-width: 2.2rem; overflow: hidden; }
+.sched-half { text-align: center; cursor: pointer; height: 0.9rem; line-height: 0.9rem; font-size: 0.6rem; overflow: hidden; transition: opacity 0.15s; }
+.sched-half:hover { opacity: 0.75; outline: 2px solid var(--primary-color); outline-offset: -1px; }
+.sched-half + .sched-half { border-top: 1px solid rgba(128,128,128,0.25); }
+.sched-half.sched-cur { outline: 2px solid #fff; outline-offset: -2px; }
+
+/* Scheduler rules list */
+.sched-rule-item { display:flex; align-items:center; gap:0.5rem; padding:0.4rem 0.6rem; border:1px solid var(--border); border-radius:var(--radius-sm); margin-bottom:0.35rem; cursor:pointer; transition:background 0.15s; }
+.sched-rule-item:hover { background:var(--surface-hover); }
+.sched-rule-active { border-color:var(--primary-color) !important; background:rgba(37,99,235,0.07); }
+.sched-rule-num { min-width:1.2rem; height:1.2rem; border-radius:0.2rem; background:var(--primary-color); color:#fff; font-size:0.7rem; font-weight:700; display:flex; align-items:center; justify-content:center; flex-shrink:0; padding:0 0.2rem; }
+.sched-rule-led { width:1rem; height:1rem; border-radius:2px; border:1px solid var(--border); flex-shrink:0; }
+.sched-rule-del { background:none; border:none; cursor:pointer; color:var(--text-secondary); font-size:0.75rem; padding:0.1rem 0.3rem; border-radius:2px; line-height:1; }
 )=====";
- 
+

--- a/TexTime.ino
+++ b/TexTime.ino
@@ -45,6 +45,7 @@
 #include "Page_mqtt.h"
 #include "Page_script.js.h"
 #include "Page_style.css.h"
+#include "Page_scheduler.h"
 
 
 
@@ -71,7 +72,7 @@ void setup() {
   Serial.println("Booting");
 
   // Config load 
-  EEPROM.begin(1024); // define an EEPROM space of 1024Bytes to store data
+  EEPROM.begin(4096); // 1024 for config + 2688 for scheduler (336 slots × 8 bytes)
   CFG_saved = ReadConfig();
   if (!CFG_saved)
   {
@@ -396,6 +397,12 @@ void setup() {
     _server.send(400, "text/html", "Page not Found");
   });
 
+  _server.on("/admin/schedulerconfig", send_scheduler_config);
+  _server.on("/admin/schedulerdata", send_scheduler_data);
+  _server.on("/admin/save/schedulerbulk", HTTP_POST, save_scheduler_bulk);
+  _server.on("/admin/scheduler/apply", HTTP_POST, apply_scheduler_now);
+  _server.on("/admin/save/schedulerenabled", HTTP_POST, save_scheduler_enabled);
+
   _httpUpdater.setup(&_server);
   _server.begin();
   Serial.println("HTTP server started");
@@ -505,6 +512,7 @@ void loop() {
   mqttPollingPublisher();
 
   // Handle led display
+  handleScheduler();
   QTLed.handle();
 
   // For debug purpose only

--- a/global.h
+++ b/global.h
@@ -44,6 +44,10 @@ struct strConfig {
 } _config;
 
 
+// Scheduler EEPROM layout: 336 slots (7 days × 48 half-hours) × 8 bytes, starting at 1024
+#define SCHEDULER_EEPROM_BASE 1024
+#define SCHEDULER_SLOT_SIZE   8
+
 //  Auxiliary function to handle EEPROM
 
 void EEPROMWritelong(int address, long value){


### PR DESCRIPTION
## Weekly Display Scheduler

Adds a configurable weekly scheduler that automatically switches the display mode and animation every half-hour.

### Features
- 7-day x 48-slot (30-min granularity) visual grid editor
- Per-slot rules: mode, animation, speed, brightness min/max, LED color, color randomization
- Color-coded grid cells (actual LED color as background, auto readable text)
- Rule numbering in cells and rule list
- Bulk EEPROM save - single POST for all 336 slots (no sequential per-slot requests)
- Rules applied automatically by `handleScheduler()` called from `loop()`
- Enable/disable toggle with EEPROM persistence

### New server routes

| Route | Method | Description |
|-------|--------|-------------|
| `/admin/schedulerconfig` | GET | Returns enabled flag |
| `/admin/schedulerdata` | GET | Returns 336 slots as hex dump |
| `/admin/save/schedulerbulk` | POST | Bulk write all 336 slots at once |
| `/admin/save/schedulerenabled` | POST | Toggle enabled flag |
| `/admin/scheduler/apply` | POST | Force immediate re-apply of current slot |

### EEPROM changes
- `EEPROM_SIZE` increased from 1024 to 4096 bytes
- Scheduler base offset: 1024, 336 slots x 8 bytes = 2688 bytes
- Slot layout: [0]=mode (0xFF=disabled), [1]=anim, [2]=(colorRandom&0x03)|((animSpeed-1)<<2), [3]=animBrightMin, [4]=animBrightMax, [5]=R, [6]=G, [7]=B

> **Breaking change**: EEPROM offsets 1024+ are overwritten. Recommend RAZ (reset all slots) after first flash.

### Files changed
- `global.h`: added SCHEDULER_EEPROM_BASE, SCHEDULER_SLOT_SIZE, bumped EEPROM_SIZE to 4096
- `TexTime.ino`: include Page_scheduler.h, new routes, handleScheduler() in loop()
- `Page_scheduler.h`: new file - all scheduler backend (read/write/bulk/apply)
- `Page_index.h`: scheduler UI section with grid editor and rule editor
- `Page_style.css.h`: scheduler grid and compact editor styles

---

## Programmateur d'affichage hebdomadaire

Ajoute un programmateur hebdomadaire configurable qui change automatiquement le mode d'affichage et l'animation toutes les demi-heures.

### Fonctionnalites
- Grille visuelle 7 jours x 48 creneaux (granularite 30 min)
- Regles par creneau : mode, animation, vitesse, luminosite min/max, couleur LED, randomisation
- Cellules colorees avec la vraie couleur LED (texte lisible automatiquement)
- Numerotation des regles dans les cellules et la liste
- Sauvegarde EEPROM groupee - un seul POST pour les 336 creneaux
- Application automatique via `handleScheduler()` appele depuis `loop()`
- Activation/desactivation avec persistance EEPROM

### Nouvelles routes serveur

| Route | Methode | Description |
|-------|---------|-------------|
| `/admin/schedulerconfig` | GET | Retourne le flag active/desactive |
| `/admin/schedulerdata` | GET | Retourne les 336 creneaux en hex |
| `/admin/save/schedulerbulk` | POST | Ecriture groupee des 336 creneaux |
| `/admin/save/schedulerenabled` | POST | Bascule le flag active/desactive |
| `/admin/scheduler/apply` | POST | Force l'application immediate du creneau courant |

### Modifications EEPROM
- `EEPROM_SIZE` augmente de 1024 a 4096 octets
- Base du programmateur : offset 1024, 336 creneaux x 8 octets = 2688 octets
- Format du creneau : [0]=mode (0xFF=desactive), [1]=anim, [2]=(colorRandom&0x03)|((animSpeed-1)<<2), [3]=animBrightMin, [4]=animBrightMax, [5]=R, [6]=G, [7]=B

> **Changement incompatible** : les offsets EEPROM a partir de 1024 sont ecrases. Faire un RAZ (remise a zero de tous les creneaux) apres le premier flash.

### Fichiers modifies
- `global.h` : ajout SCHEDULER_EEPROM_BASE, SCHEDULER_SLOT_SIZE, EEPROM_SIZE passe a 4096
- `TexTime.ino` : inclusion Page_scheduler.h, nouvelles routes, handleScheduler() dans loop()
- `Page_scheduler.h` : nouveau fichier - toute la logique backend du programmateur
- `Page_index.h` : section UI du programmateur avec grille et editeur de regles
- `Page_style.css.h` : styles de la grille et de l'editeur compact