### PR TITLE
Feat: translate web interface based on selected language (FR/EN)

### DIFF
--- a/Page_general.h
+++ b/Page_general.h
@@ -73,6 +73,9 @@ void send_general_configuration_values_html()
   values += "colorrandom|" + (String)_config.colorRandom + "|input\n";
   values += "ledconfig|" + (String)_config.ledConfig + "|input\n";
   values += "brightnesssensibility|" + (String)_config.luxSensitivity + "|input\n";
+  values += "animspeed|" + (String)_config.animSpeed + "|input\n";
+  values += "animbrightmin|" + (String)_config.animBrightnessMin + "|input\n";
+  values += "animbrightmax|" + (String)_config.animBrightnessMax + "|input\n";
 
 	_server.send(200, "text/plain", values);
 	//Serial.println(__FUNCTION__); 
@@ -120,6 +123,11 @@ void send_general_animations_values_html()
     values += "animation|" + (*pl)[i]->getName() + "|select\n";
 
   _server.send(200, "text/plain", values);
+}
+
+void send_lang_value_html()
+{
+  _server.send(200, "text/plain", String(_config.language));
 }
 
 void send_general_led()
@@ -180,9 +188,16 @@ void send_general_led()
         QTLed.setColorRandom((RandomColorMode)_server.arg(i).toInt());
       }
       if (_server.argName(i) == "brightnesssensibility")
-      {
         _config.luxSensitivity = _server.arg(i).toInt();
-      }
+
+      if (_server.argName(i) == "animspeed")
+        QTLed.setAnimSpeed(constrain(_server.arg(i).toInt(), 1, 20));
+
+      if (_server.argName(i) == "animbrightmin")
+        _config.animBrightnessMin = constrain(_server.arg(i).toInt(), 0, 100);
+
+      if (_server.argName(i) == "animbrightmax")
+        _config.animBrightnessMax = constrain(_server.arg(i).toInt(), 0, 100);
     }
   }
   _server.send(200, "text/plain", "OK");

--- a/Page_index.h
+++ b/Page_index.h
@@ -43,6 +43,10 @@ const char PAGE_index[] PROGMEM = R"=====(
           <span class="nav-icon">🔄</span>
           <span>Firmware Update</span>
         </button>
+        <button class="nav-item" data-section="scheduler">
+          <span class="nav-icon">&#x23F0;</span>
+          <span>Scheduler</span>
+        </button>
       </div>
     </nav>
 
@@ -430,6 +434,75 @@ const char PAGE_index[] PROGMEM = R"=====(
           </div>
         </section>
 
+        <!-- Scheduler Section -->
+        <section id="scheduler-section" class="content-section">
+          <div class="dashboard-grid">
+            <div class="card">
+              <div class="card-title">Weekly Schedule</div>
+              <div class="form-group">
+                <div class="checkbox-group">
+                  <input type="checkbox" id="schedulerEnabled" class="checkbox" onchange="saveSchedulerEnabled()">
+                  <label for="schedulerEnabled" class="form-label">Enable scheduler (applies each half-hour, overrides general settings)</label>
+                </div>
+              </div>
+              <p style="font-size:0.8rem;color:var(--text-secondary);margin-bottom:0.75rem">Select a rule on the right, then click/drag cells to paint them. Click a painted cell again to erase it.</p>
+              <div id="schedGrid" class="sched-grid-wrap"><div class="loading">Loading...</div></div>
+            </div>
+            <div class="card sched-editor">
+              <div class="card-title">Rules</div>
+              <div id="schedRulesList" style="margin-bottom:0.4rem"></div>
+              <button class="btn btn-secondary btn-block" onclick="schedAddRule()" style="margin-bottom:0.4rem">+ New rule</button>
+              <hr style="border:none;border-top:1px solid var(--border);margin-bottom:0.4rem">
+              <div class="form-group">
+                <label class="form-label">Display mode</label>
+                <select id="schedMode" class="form-control" onchange="schedEditorChange()"></select>
+              </div>
+              <div class="form-group">
+                <label class="form-label">Color</label>
+                <input type="color" id="schedColor" value="#ffffff" class="form-control" style="height:2rem;padding:0.1rem;cursor:pointer" onchange="schedEditorChange()">
+              </div>
+              <div class="form-group">
+                <label class="form-label">Color randomization</label>
+                <select id="schedColorRandom" class="form-control" onchange="schedEditorChange()">
+                  <option value="0">No Random</option>
+                  <option value="1">Random all</option>
+                  <option value="2">Random letter</option>
+                  <option value="3">Random word</option>
+                </select>
+              </div>
+              <div class="form-group">
+                <label class="form-label">Animation</label>
+                <select id="schedAnimation" class="form-control" onchange="schedEditorChange()"></select>
+              </div>
+              <div class="form-group">
+                <label class="form-label">Speed (1=slow, 20=fast)</label>
+                <div class="range-group">
+                  <input type="range" id="schedAnimSpeed" class="range-input" min="1" max="20" step="1" oninput="document.getElementById('schedAnimSpeedT').textContent=this.value;schedEditorChange()">
+                  <div class="range-value" id="schedAnimSpeedT">10</div>
+                </div>
+              </div>
+              <div class="form-group">
+                <label class="form-label">Min brightness (%)</label>
+                <div class="range-group">
+                  <input type="range" id="schedAnimBrightMin" class="range-input" min="0" max="100" step="1" oninput="document.getElementById('schedAnimBrightMinT').textContent=this.value;schedEditorChange()">
+                  <div class="range-value" id="schedAnimBrightMinT">10</div>
+                </div>
+              </div>
+              <div class="form-group">
+                <label class="form-label">Max brightness (%)</label>
+                <div class="range-group">
+                  <input type="range" id="schedAnimBrightMax" class="range-input" min="0" max="100" step="1" oninput="document.getElementById('schedAnimBrightMaxT').textContent=this.value;schedEditorChange()">
+                  <div class="range-value" id="schedAnimBrightMaxT">100</div>
+                </div>
+              </div>
+              <div style="display:flex;gap:0.5rem;margin-top:0.5rem">
+                <button class="btn btn-secondary" onclick="schedRaz()" style="flex:1">RAZ</button>
+                <button class="btn btn-primary" id="schedSaveBtn" onclick="saveAllScheduler()" style="flex:2">Save</button>
+              </div>
+            </div>
+          </div>
+        </section>
+
         <!-- Update Section -->
         <section id="update-section" class="content-section">
           <div class="dashboard-grid">
@@ -516,7 +589,8 @@ const char PAGE_index[] PROGMEM = R"=====(
       'network': 'Network Configuration',
       'ntp': 'Time Configuration',
       'mqtt': 'MQTT Configuration',
-      'update': 'Firmware Update'
+      'update': 'Firmware Update',
+      'scheduler': 'Display Scheduler'
     };
 
     // Utility functions
@@ -638,6 +712,9 @@ const char PAGE_index[] PROGMEM = R"=====(
           break;
         case 'mqtt':
           loadMqttSettings();
+          break;
+        case 'scheduler':
+          loadSchedulerSettings();
           break;
       }
     }
@@ -1198,6 +1275,267 @@ const char PAGE_index[] PROGMEM = R"=====(
         closeMobileMenu();
       }
     });
+
+    // ── Scheduler ──────────────────────────────────────────────────────────────
+    function toHex2(v){var h=Math.round(v).toString(16);return h.length<2?'0'+h:h;}
+    function schedTextColor(r,g,b){return (r*299+g*587+b*114)/1000>128?'#111':'#fff';}
+    var schedCells=new Array(336).fill(null);
+    var schedRules=[];
+    var schedCurrentRule=0;
+    var schedModeNames=[],schedAnimNames=[];
+    var schedDragging=false,schedDragMode=null;
+
+    function schedEditorChange() {
+      if(!schedRules.length) return;
+      var r=schedRules[schedCurrentRule];
+      r.mode=parseInt(document.getElementById('schedMode').value);
+      r.anim=parseInt(document.getElementById('schedAnimation').value);
+      r.colorRandom=parseInt(document.getElementById('schedColorRandom').value);
+      r.animSpeed=parseInt(document.getElementById('schedAnimSpeed').value);
+      r.animBrightMin=parseInt(document.getElementById('schedAnimBrightMin').value);
+      r.animBrightMax=parseInt(document.getElementById('schedAnimBrightMax').value);
+      var ch=document.getElementById('schedColor').value.replace('#','');
+      r.r=parseInt(ch.substr(0,2),16)||0;
+      r.g=parseInt(ch.substr(2,2),16)||0;
+      r.b=parseInt(ch.substr(4,2),16)||0;
+      schedRenderRulesList();
+      var hex='#'+toHex2(r.r)+toHex2(r.g)+toHex2(r.b);
+      var tc=schedTextColor(r.r,r.g,r.b);
+      document.querySelectorAll('#schedGrid .sched-half.sched-cur').forEach(function(el){
+        el.style.background=hex; el.style.color=tc;
+      });
+    }
+
+    function schedLoadEditor(rule) {
+      document.getElementById('schedMode').value=rule.mode;
+      document.getElementById('schedColorRandom').value=rule.colorRandom;
+      document.getElementById('schedAnimation').value=rule.anim;
+      document.getElementById('schedAnimSpeed').value=rule.animSpeed;
+      document.getElementById('schedAnimSpeedT').textContent=rule.animSpeed;
+      document.getElementById('schedAnimBrightMin').value=rule.animBrightMin;
+      document.getElementById('schedAnimBrightMinT').textContent=rule.animBrightMin;
+      document.getElementById('schedAnimBrightMax').value=rule.animBrightMax;
+      document.getElementById('schedAnimBrightMaxT').textContent=rule.animBrightMax;
+      document.getElementById('schedColor').value='#'+toHex2(rule.r)+toHex2(rule.g)+toHex2(rule.b);
+    }
+
+    function schedRenderRulesList() {
+      var el=document.getElementById('schedRulesList');
+      var crNames=['no random','rnd all','rnd letter','rnd word'];
+      var html='';
+      schedRules.forEach(function(rule,i){
+        var ledHex='#'+toHex2(rule.r)+toHex2(rule.g)+toHex2(rule.b);
+        var mname=schedModeNames[rule.mode]||'mode '+rule.mode;
+        var crname=crNames[rule.colorRandom]||'';
+        var aname=schedAnimNames[rule.anim]||'anim '+rule.anim;
+        var label=mname+' - '+crname+' - '+aname;
+        var active=i===schedCurrentRule;
+        html+='<div class="sched-rule-item'+(active?' sched-rule-active':'')+'" onclick="schedSelectRule('+i+')">'
+          +'<div class="sched-rule-num">'+(i+1)+'</div>'
+          +'<div style="flex:1;font-size:0.8rem">'+label+'</div>'
+          +'<div class="sched-rule-led" style="background:'+ledHex+'" title="LED color"></div>'
+          +'<button class="sched-rule-del" onclick="event.stopPropagation();schedDelRule('+i+')" title="Delete">&#x2715;</button>'
+          +'</div>';
+      });
+      el.innerHTML=html;
+    }
+
+    function schedSelectRule(idx) {
+      schedCurrentRule=idx;
+      schedLoadEditor(schedRules[idx]);
+      schedRenderRulesList();
+      renderSchedulerGrid();
+    }
+
+    function schedAddRule() {
+      schedRules.push({mode:0,anim:0,colorRandom:0,animSpeed:10,animBrightMin:10,animBrightMax:100,r:0,g:0,b:0});
+      schedSelectRule(schedRules.length-1);
+    }
+
+    function schedDelRule(idx) {
+      if(schedRules.length<=1) return;
+      schedRules.splice(idx,1);
+      for(var i=0;i<336;i++){
+        if(schedCells[i]===idx) schedCells[i]=null;
+        else if(schedCells[i]>idx) schedCells[i]--;
+      }
+      if(schedCurrentRule>=schedRules.length) schedCurrentRule=schedRules.length-1;
+      schedLoadEditor(schedRules[schedCurrentRule]);
+      schedRenderRulesList();
+      renderSchedulerGrid();
+    }
+
+    function renderSchedulerGrid() {
+      var days=['Mon','Tue','Wed','Thu','Fri','Sat','Sun'];
+      var html='<table class="sched-table"><thead><tr><th></th>';
+      days.forEach(function(d){html+='<th>'+d+'</th>';});
+      html+='</tr></thead><tbody>';
+      for(var h=0;h<24;h++){
+        html+='<tr><td class="sched-hour">'+(h<10?'0':'')+h+'h</td>';
+        for(var d=0;d<7;d++){
+          html+='<td class="sched-cell">';
+          for(var m=0;m<2;m++){
+            var idx=d*48+h*2+m;
+            var ri=schedCells[idx];
+            var style='',label='';
+            if(ri!==null&&ri!==undefined){
+              var rr=schedRules[ri];
+              style='background:#'+toHex2(rr.r)+toHex2(rr.g)+toHex2(rr.b)+';color:'+schedTextColor(rr.r,rr.g,rr.b)+';';
+              label=String(ri+1);
+            }
+            var isCur=(ri===schedCurrentRule)?'sched-cur':'';
+            html+='<div class="sched-half '+isCur+'" data-d="'+d+'" data-h="'+h+'" data-m="'+(m*30)+'" style="'+style+'">'+label+'</div>';
+          }
+          html+='</td>';
+        }
+        html+='</tr>';
+      }
+      html+='</tbody></table>';
+      document.getElementById('schedGrid').innerHTML=html;
+      schedInitGridEvents();
+    }
+
+    function schedCellAt(el) {
+      var c=el&&el.closest?el.closest('[data-d]'):null;
+      if(!c||!c.classList.contains('sched-half')) return null;
+      var d=parseInt(c.dataset.d),h=parseInt(c.dataset.h),m=parseInt(c.dataset.m);
+      return {el:c,idx:d*48+h*2+(m>=30?1:0)};
+    }
+
+    function schedPaintEl(info) {
+      var ri=schedCells[info.idx];
+      if(ri!==null&&ri!==undefined){
+        var rr=schedRules[ri];
+        info.el.style.background='#'+toHex2(rr.r)+toHex2(rr.g)+toHex2(rr.b);
+        info.el.style.color=schedTextColor(rr.r,rr.g,rr.b);
+        info.el.textContent=String(ri+1);
+        info.el.className='sched-half'+(ri===schedCurrentRule?' sched-cur':'');
+      } else {
+        info.el.style.cssText='';
+        info.el.textContent='';
+        info.el.className='sched-half';
+      }
+    }
+
+    function schedInitGridEvents() {
+      var grid=document.getElementById('schedGrid');
+      if(!grid||grid._ei) return;
+      grid._ei=true;
+      function ptInfo(x,y){return schedCellAt(document.elementFromPoint(x,y));}
+      function onStart(x,y){
+        var info=ptInfo(x,y); if(!info) return;
+        schedDragging=true;
+        schedDragMode=(schedCells[info.idx]===schedCurrentRule)?'remove':'add';
+        schedCells[info.idx]=schedDragMode==='add'?schedCurrentRule:null;
+        schedPaintEl(info);
+      }
+      function onMove(x,y){
+        if(!schedDragging) return;
+        var info=ptInfo(x,y); if(!info) return;
+        if(schedDragMode==='add'&&schedCells[info.idx]!==schedCurrentRule){
+          schedCells[info.idx]=schedCurrentRule; schedPaintEl(info);
+        } else if(schedDragMode==='remove'&&schedCells[info.idx]!==null){
+          schedCells[info.idx]=null; schedPaintEl(info);
+        }
+      }
+      function onEnd(){schedDragging=false;schedDragMode=null;}
+      grid.addEventListener('mousedown',function(e){onStart(e.clientX,e.clientY);e.preventDefault();});
+      document.addEventListener('mousemove',function(e){onMove(e.clientX,e.clientY);});
+      document.addEventListener('mouseup',onEnd);
+      grid.addEventListener('touchstart',function(e){onStart(e.touches[0].clientX,e.touches[0].clientY);e.preventDefault();},{passive:false});
+      document.addEventListener('touchmove',function(e){if(schedDragging){onMove(e.touches[0].clientX,e.touches[0].clientY);e.preventDefault();}},{passive:false});
+      document.addEventListener('touchend',onEnd);
+    }
+
+    function schedRaz() {
+      if(!confirm('Clear all scheduled slots?')) return;
+      schedCells=new Array(336).fill(null);
+      renderSchedulerGrid();
+    }
+
+    function loadSchedulerSettings() {
+      setValues('/admin/schedulerconfig')
+        .then(function(){
+          return fetch('/admin/generalmodesvalues').then(function(r){return r.text();}).then(function(txt){
+            schedModeNames=[];
+            txt.split('\n').forEach(function(l){var p=l.split('|');if(p.length>=2&&p[1])schedModeNames.push(p[1]);});
+          });
+        })
+        .then(function(){
+          return fetch('/admin/generalanimationsvalues').then(function(r){return r.text();}).then(function(txt){
+            schedAnimNames=[];
+            txt.split('\n').forEach(function(l){var p=l.split('|');if(p.length>=2&&p[1])schedAnimNames.push(p[1]);});
+            var ms=document.getElementById('schedMode');ms.innerHTML='';
+            schedModeNames.forEach(function(n,i){var o=document.createElement('option');o.value=i;o.textContent=n;ms.appendChild(o);});
+            var as=document.getElementById('schedAnimation');as.innerHTML='';
+            schedAnimNames.forEach(function(n,i){var o=document.createElement('option');o.value=i;o.textContent=n;as.appendChild(o);});
+          });
+        })
+        .then(function(){
+          return fetch('/admin/schedulerdata').then(function(r){return r.text();}).then(function(txt){
+            schedCells=new Array(336).fill(null);
+            schedRules=[];
+            var ruleMap={};
+            for(var i=0;i<336;i++){
+              var hex=txt.substr(i*16,16);
+              if(hex.length<16) continue;
+              var b0=parseInt(hex.substr(0,2),16);
+              if(b0===0xFF) continue;
+              var key=hex;
+              if(ruleMap[key]===undefined){
+                var b1=parseInt(hex.substr(2,2),16);
+                var b2=parseInt(hex.substr(4,2),16);
+                ruleMap[key]=schedRules.length;
+                schedRules.push({
+                  mode:b0,anim:b1,
+                  colorRandom:b2&0x03,animSpeed:((b2>>2)&0x1F)+1,
+                  animBrightMin:parseInt(hex.substr(6,2),16),
+                  animBrightMax:parseInt(hex.substr(8,2),16),
+                  r:parseInt(hex.substr(10,2),16),
+                  g:parseInt(hex.substr(12,2),16),
+                  b:parseInt(hex.substr(14,2),16)
+                });
+              }
+              schedCells[i]=ruleMap[key];
+            }
+            if(!schedRules.length) schedRules.push({mode:1,anim:0,colorRandom:0,animSpeed:10,animBrightMin:10,animBrightMax:100,r:255,g:255,b:255});
+            schedCurrentRule=0;
+            schedLoadEditor(schedRules[0]);
+            schedRenderRulesList();
+            renderSchedulerGrid();
+          });
+        });
+    }
+
+    function saveSchedulerEnabled() {
+      var en=document.getElementById('schedulerEnabled').checked?'1':'0';
+      fetch('/admin/save/schedulerenabled',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:'enabled='+en});
+    }
+
+    async function saveAllScheduler() {
+      var btn=document.getElementById('schedSaveBtn');
+      setSaveButtonState(btn,'saving');
+      try {
+        var hex='';
+        for(var i=0;i<336;i++){
+          var ri=schedCells[i];
+          if(ri===null||ri===undefined){
+            hex+='FFFFFFFFFFFFFFFF';
+          } else {
+            var rule=schedRules[ri];
+            var packed=(rule.colorRandom&0x03)|((rule.animSpeed-1)<<2);
+            hex+=toHex2(rule.mode)+toHex2(rule.anim)+toHex2(packed)
+                +toHex2(rule.animBrightMin)+toHex2(rule.animBrightMax)
+                +toHex2(rule.r)+toHex2(rule.g)+toHex2(rule.b);
+          }
+        }
+        await fetch('/admin/save/schedulerbulk',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:'data='+hex});
+        await fetch('/admin/scheduler/apply',{method:'POST'});
+        setSaveButtonState(btn,'success');
+      } catch(e){setSaveButtonState(btn,'error');}
+    }
+    // ── End Scheduler ──────────────────────────────────────────────────────────
+
   </script>
 </body>
 </html>

--- a/Page_index.h
+++ b/Page_index.h
@@ -21,32 +21,40 @@ const char PAGE_index[] PROGMEM = R"=====(
       <div class="sidebar-nav">
         <button class="nav-item active" data-section="info">
           <span class="nav-icon">ℹ</span>
-          <span>System Information</span>
+          <span data-i18n="nav.info">System Information</span>
         </button>
         <button class="nav-item" data-section="general">
           <span class="nav-icon">⚙</span>
-          <span>General Settings</span>
+          <span data-i18n="nav.general">General Settings</span>
         </button>
         <button class="nav-item" data-section="network">
           <span class="nav-icon">📶</span>
-          <span>Network Configuration</span>
+          <span data-i18n="nav.network">Network Configuration</span>
         </button>
         <button class="nav-item" data-section="ntp">
           <span class="nav-icon">🕐</span>
-          <span>Time Configuration</span>
+          <span data-i18n="nav.ntp">Time Configuration</span>
         </button>
         <button class="nav-item" data-section="mqtt">
           <span class="nav-icon">📡</span>
-          <span>MQTT Configuration</span>
+          <span data-i18n="nav.mqtt">MQTT Configuration</span>
         </button>
         <button class="nav-item" data-section="update">
           <span class="nav-icon">🔄</span>
-          <span>Firmware Update</span>
+          <span data-i18n="nav.update">Firmware Update</span>
         </button>
         <button class="nav-item" data-section="scheduler">
           <span class="nav-icon">&#x23F0;</span>
-          <span>Scheduler</span>
+          <span data-i18n="nav.scheduler">Scheduler</span>
         </button>
+        <a class="nav-item" href="/tetris.html" style="text-decoration:none;">
+          <span class="nav-icon">🎮</span>
+          <span>Tetris</span>
+        </a>
+        <a class="nav-item" href="/snake.html" style="text-decoration:none;">
+          <span class="nav-icon">🐍</span>
+          <span>Snake</span>
+        </a>
       </div>
     </nav>
 
@@ -68,58 +76,58 @@ const char PAGE_index[] PROGMEM = R"=====(
         <section id="info-section" class="content-section active">
           <div class="dashboard-grid">
             <div class="card">
-              <div class="card-title">System Status</div>
+              <div class="card-title" data-i18n="card.system_status">System Status</div>
               <div class="status-grid">
                 <div class="status-item">
-                  <div class="status-label">Current Date</div>
+                  <div class="status-label" data-i18n="lbl.current_date">Current Date</div>
                   <div class="status-value" id="x_date">Loading...</div>
                 </div>
                 <div class="status-item">
-                  <div class="status-label">Uptime</div>
+                  <div class="status-label" data-i18n="lbl.uptime">Uptime</div>
                   <div class="status-value" id="x_boot">Loading...</div>
                 </div>
                 <div class="status-item">
-                  <div class="status-label">Firmware Build</div>
+                  <div class="status-label" data-i18n="lbl.firmware_build">Firmware Build</div>
                   <div class="status-value" id="x_version">Loading...</div>
                 </div>
               </div>
             </div>
 
             <div class="card">
-              <div class="card-title">Network Information</div>
+              <div class="card-title" data-i18n="card.network_info">Network Information</div>
               <div class="status-grid">
                 <div class="status-item">
-                  <div class="status-label">WiFi Network</div>
+                  <div class="status-label" data-i18n="lbl.wifi_network">WiFi Network</div>
                   <div class="status-value" id="x_ssid">Loading...</div>
                 </div>
                 <div class="status-item">
-                  <div class="status-label">Signal Strength</div>
+                  <div class="status-label" data-i18n="lbl.signal_strength">Signal Strength</div>
                   <div class="status-value"><span id="x_rssi">-</span>%</div>
                 </div>
                 <div class="status-item">
-                  <div class="status-label">IP Address</div>
+                  <div class="status-label" data-i18n="lbl.ip_address">IP Address</div>
                   <div class="status-value" id="x_ip">Loading...</div>
                 </div>
                 <div class="status-item">
-                  <div class="status-label">MAC Address</div>
+                  <div class="status-label" data-i18n="lbl.mac_address">MAC Address</div>
                   <div class="status-value" id="x_mac">Loading...</div>
                 </div>
               </div>
             </div>
 
             <div class="card">
-              <div class="card-title">Sensor Readings</div>
+              <div class="card-title" data-i18n="card.sensors">Sensor Readings</div>
               <div class="status-grid">
                 <div class="status-item">
-                  <div class="status-label">Ambient Light</div>
+                  <div class="status-label" data-i18n="lbl.ambient_light">Ambient Light</div>
                   <div class="status-value"><span id="x_als">-</span> lux</div>
                 </div>
                 <div class="status-item">
-                  <div class="status-label">Display Brightness</div>
+                  <div class="status-label" data-i18n="lbl.display_brightness">Display Brightness</div>
                   <div class="status-value" id="x_brightness">-</div>
                 </div>
                 <div class="status-item">
-                  <div class="status-label">Temperature</div>
+                  <div class="status-label" data-i18n="lbl.temperature">Temperature</div>
                   <div class="status-value"><span id="x_temp">-</span> °C</div>
                 </div>
               </div>
@@ -131,29 +139,29 @@ const char PAGE_index[] PROGMEM = R"=====(
         <section id="general-section" class="content-section">
           <div class="dashboard-grid">
             <div class="card">
-              <div class="card-title">Brightness Control</div>
+              <div class="card-title" data-i18n="card.brightness">Brightness Control</div>
               <form id="general-form" onsubmit="return saveGeneralSettings(event)">
 
             <div class="form-group">
               <div class="checkbox-group">
                 <input type="checkbox" id="brightnessauto" name="brightnessauto" class="checkbox" onchange="updatebrightnessauto()">
-                <label for="brightnessauto" class="form-label">Automatic brightness</label>
+                <label for="brightnessauto" class="form-label" data-i18n="lbl.auto_brightness">Automatic brightness</label>
               </div>
             </div>
 
             <div class="form-group">
-              <label for="brightnesssensibility" class="form-label">Brightness sensitivity</label>
+              <label for="brightnesssensibility" class="form-label" data-i18n="lbl.brightness_sensitivity">Brightness sensitivity</label>
               <select id="brightnesssensibility" name="brightnesssensibility" class="form-control" onchange="updatebrightnesssensibility()">
-                <option value="10">Very high</option>
-                <option value="20">High</option>
-                <option value="30">Normal</option>
-                <option value="40">Low</option>
-                <option value="50">Very low</option>
+                <option value="10" data-i18n="opt.very_high">Very high</option>
+                <option value="20" data-i18n="opt.high">High</option>
+                <option value="30" data-i18n="opt.normal">Normal</option>
+                <option value="40" data-i18n="opt.low">Low</option>
+                <option value="50" data-i18n="opt.very_low">Very low</option>
               </select>
             </div>
 
             <div class="form-group">
-              <label for="brightness" class="form-label">Manual brightness</label>
+              <label for="brightness" class="form-label" data-i18n="lbl.manual_brightness">Manual brightness</label>
               <div class="range-group">
                 <input type="range" id="brightness" name="brightness" class="range-input" max="255" min="0" step="1" oninput="updatebrightness()">
                 <div class="range-value" id="brightnesst">--</div>
@@ -161,7 +169,7 @@ const char PAGE_index[] PROGMEM = R"=====(
             </div>
 
             <div class="form-group">
-              <label for="brightnessday" class="form-label">Minimum day brightness</label>
+              <label for="brightnessday" class="form-label" data-i18n="lbl.day_brightness">Minimum day brightness</label>
               <div class="range-group">
                 <input type="range" id="brightnessday" name="brightnessday" class="range-input" max="255" min="0" step="1" oninput="updatebrightnessday()">
                 <div class="range-value" id="brightnessdayt">--</div>
@@ -169,7 +177,7 @@ const char PAGE_index[] PROGMEM = R"=====(
             </div>
 
             <div class="form-group">
-              <label for="brightnessnight" class="form-label">Minimum night brightness</label>
+              <label for="brightnessnight" class="form-label" data-i18n="lbl.night_brightness">Minimum night brightness</label>
               <div class="range-group">
                 <input type="range" id="brightnessnight" name="brightnessnight" class="range-input" max="255" min="0" step="1" oninput="updatebrightnessnight()">
                 <div class="range-value" id="brightnessnightt">--</div>
@@ -178,16 +186,16 @@ const char PAGE_index[] PROGMEM = R"=====(
           </div>
 
             <div class="card">
-              <div class="card-title">Display Configuration</div>
+              <div class="card-title" data-i18n="card.display_config">Display Configuration</div>
 
               <div class="form-group">
-                <label for="ledconfig" class="form-label">Clock type</label>
+                <label for="ledconfig" class="form-label" data-i18n="lbl.clock_type">Clock type</label>
                 <select id="ledconfig" name="ledconfig" class="form-control">
                 </select>
               </div>
 
             <div class="form-group">
-              <label for="color" class="form-label">Color</label>
+              <label for="color" class="form-label" data-i18n="lbl.color">Color</label>
               <div class="color-picker-container">
                 <input type="color" id="color" name="color" class="color-picker-input">
                 <input type="text" id="colorText" class="color-text-input" placeholder="#FF0000" maxlength="7">
@@ -195,34 +203,58 @@ const char PAGE_index[] PROGMEM = R"=====(
             </div>
 
             <div class="form-group">
-              <label for="colorrandom" class="form-label">Color randomization</label>
+              <label for="colorrandom" class="form-label" data-i18n="lbl.color_random">Color randomization</label>
               <select id="colorrandom" name="colorrandom" class="form-control" onchange="updatecolorrandom()">
-                <option value="0">No Random</option>
-                <option value="1">Random all</option>
-                <option value="2">Random letter</option>
-                <option value="3">Random word</option>
+                <option value="0" data-i18n="opt.no_random">No Random</option>
+                <option value="1" data-i18n="opt.random_all">Random all</option>
+                <option value="2" data-i18n="opt.random_letter">Random letter</option>
+                <option value="3" data-i18n="opt.random_word">Random word</option>
               </select>
             </div>
 
             <div class="form-group">
-              <label for="lang" class="form-label">Language</label>
+              <label for="lang" class="form-label" data-i18n="lbl.language">Language</label>
               <select id="lang" name="lang" class="form-control" onchange="updatelang()">
               </select>
             </div>
 
             <div class="form-group">
-              <label for="mode" class="form-label">Display mode</label>
+              <label for="mode" class="form-label" data-i18n="lbl.display_mode">Display mode</label>
               <select id="mode" name="mode" class="form-control" onchange="updatemode()">
               </select>
             </div>
 
                 <div class="form-group">
-                  <label for="animation" class="form-label">Animation</label>
+                  <label for="animation" class="form-label" data-i18n="lbl.animation">Animation</label>
                   <select id="animation" name="animation" class="form-control" onchange="updateanimation()">
                   </select>
                 </div>
 
-                <button type="submit" class="btn btn-primary btn-block">Save Configuration</button>
+                <div class="form-group">
+                  <label for="animspeed" class="form-label" data-i18n="lbl.anim_speed">Animation speed (1=slow, 20=fast)</label>
+                  <div class="range-group">
+                    <input type="range" id="animspeed" name="animspeed" class="range-input" min="1" max="20" step="1" oninput="updateanimspeed()">
+                    <div class="range-value" id="animspeedt">--</div>
+                  </div>
+                </div>
+
+                <div class="form-group">
+                  <label for="animbrightmin" class="form-label" data-i18n="lbl.anim_bright_min">Animation min brightness (%)</label>
+                  <div class="range-group">
+                    <input type="range" id="animbrightmin" name="animbrightmin" class="range-input" min="0" max="100" step="1" oninput="updateanimbrightmin()">
+                    <div class="range-value" id="animbrightmint">--</div>
+                  </div>
+                </div>
+
+                <div class="form-group">
+                  <label for="animbrightmax" class="form-label" data-i18n="lbl.anim_bright_max">Animation max brightness (%)</label>
+                  <div class="range-group">
+                    <input type="range" id="animbrightmax" name="animbrightmax" class="range-input" min="0" max="100" step="1" oninput="updateanimbrightmax()">
+                    <div class="range-value" id="animbrightmaxt">--</div>
+                  </div>
+                </div>
+
+                <button type="submit" class="btn btn-primary btn-block" data-i18n="btn.save">Save Configuration</button>
               </form>
             </div>
           </div>
@@ -232,71 +264,71 @@ const char PAGE_index[] PROGMEM = R"=====(
         <section id="network-section" class="content-section">
           <div class="dashboard-grid">
             <div class="card compact-status">
-              <div class="card-title">Connection Status</div>
+              <div class="card-title" data-i18n="card.connection_status">Connection Status</div>
               <div class="status-item">
-                <div class="status-label">Current Status</div>
+                <div class="status-label" data-i18n="lbl.current_status">Current Status</div>
                 <div class="status-value" id="connectionstatedisplay">Checking...</div>
                 <div id="connectionstate" style="display: none;">Checking...</div>
               </div>
             </div>
 
             <div class="card">
-              <div class="card-title">WiFi Settings</div>
+              <div class="card-title" data-i18n="card.wifi_settings">WiFi Settings</div>
               <form id="network-form" onsubmit="return saveNetworkSettings(event)">
             <div class="form-group">
-              <label for="ssid" class="form-label">Network name (SSID)</label>
+              <label for="ssid" class="form-label" data-i18n="lbl.ssid">Network name (SSID)</label>
               <input type="text" id="ssid" name="ssid" class="form-control" placeholder="Enter network name">
             </div>
 
             <div class="form-group">
-              <label for="password" class="form-label">Password</label>
+              <label for="password" class="form-label" data-i18n="lbl.password">Password</label>
               <input type="password" id="password" name="password" class="form-control" placeholder="Enter network password">
             </div>
 
             <div class="form-group">
-              <label for="devicename" class="form-label">Device name</label>
+              <label for="devicename" class="form-label" data-i18n="lbl.device_name">Device name</label>
               <input type="text" id="devicename" name="devicename" class="form-control" placeholder="TexTime">
             </div>
 
             <div class="form-group">
               <div class="checkbox-group">
                 <input type="checkbox" id="dhcp" name="dhcp" class="checkbox" onchange="validateNetworkSettings()">
-                <label for="dhcp" class="form-label">Use DHCP (automatic IP configuration)</label>
+                <label for="dhcp" class="form-label" data-i18n="lbl.dhcp">Use DHCP (automatic IP configuration)</label>
               </div>
             </div>
 
             <div id="static-config">
               <div class="form-group">
-                <label class="form-label">IP Address</label>
+                <label class="form-label" data-i18n="lbl.ip_address">IP Address</label>
                 <input type="text" id="ipaddress" name="ipaddress" class="form-control" placeholder="192.168.1.100" pattern="^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$">
               </div>
 
               <div class="form-group">
-                <label class="form-label">Subnet Mask</label>
+                <label class="form-label" data-i18n="lbl.subnet_mask">Subnet Mask</label>
                 <input type="text" id="netmask" name="netmask" class="form-control" placeholder="255.255.255.0" pattern="^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$">
               </div>
 
               <div class="form-group">
-                <label class="form-label">Gateway</label>
+                <label class="form-label" data-i18n="lbl.gateway">Gateway</label>
                 <input type="text" id="gateway" name="gateway" class="form-control" placeholder="192.168.1.1" pattern="^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$">
               </div>
 
               <div class="form-group">
-                <label class="form-label">DNS Server</label>
+                <label class="form-label" data-i18n="lbl.dns_server">DNS Server</label>
                 <input type="text" id="dnsserver" name="dnsserver" class="form-control" placeholder="8.8.8.8" pattern="^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$">
               </div>
             </div>
 
-                <button type="submit" class="btn btn-primary btn-block">Save & Restart</button>
+                <button type="submit" class="btn btn-primary btn-block" data-i18n="btn.save_restart">Save & Restart</button>
               </form>
             </div>
 
             <div class="card">
-              <div class="card-title">Available Networks</div>
+              <div class="card-title" data-i18n="card.available_networks">Available Networks</div>
               <div id="networks" class="networks-list">
-                <div class="loading">Scanning for networks...</div>
+                <div class="loading" data-i18n="msg.scanning">Scanning for networks...</div>
               </div>
-              <button type="button" onclick="refreshNetworks()" class="btn btn-secondary btn-block">Refresh Networks</button>
+              <button type="button" onclick="refreshNetworks()" class="btn btn-secondary btn-block" data-i18n="btn.refresh_networks">Refresh Networks</button>
             </div>
           </div>
         </section>
@@ -305,23 +337,23 @@ const char PAGE_index[] PROGMEM = R"=====(
         <section id="ntp-section" class="content-section">
           <div class="dashboard-grid">
             <div class="card">
-              <div class="card-title">Time Synchronization Settings</div>
+              <div class="card-title" data-i18n="card.ntp_settings">Time Synchronization Settings</div>
               <form id="ntp-form" onsubmit="return saveNtpSettings(event)">
             <div class="form-group">
-              <label for="ntpserver" class="form-label">NTP Server</label>
+              <label for="ntpserver" class="form-label" data-i18n="lbl.ntp_server">NTP Server</label>
               <input type="text" id="ntpserver" name="ntpserver" class="form-control" maxlength="172" placeholder="pool.ntp.org">
             </div>
 
             <div class="form-group">
-              <label for="update" class="form-label">Update interval</label>
+              <label for="update" class="form-label" data-i18n="lbl.update_interval">Update interval</label>
               <div class="form-control-group">
                 <input type="number" id="update" name="update" class="form-control" maxlength="6" placeholder="3600" min="0">
-                <span>seconds (0 = disabled)</span>
+                <span data-i18n="lbl.seconds_disabled">seconds (0 = disabled)</span>
               </div>
             </div>
 
             <div class="form-group">
-              <label for="tz" class="form-label">Timezone</label>
+              <label for="tz" class="form-label" data-i18n="lbl.timezone">Timezone</label>
               <select id="tz" name="tz" class="form-control">
                 <option value="-120">(GMT-12:00) Baker Island</option>
                 <option value="-110">(GMT-11:00) Samoa</option>
@@ -362,11 +394,11 @@ const char PAGE_index[] PROGMEM = R"=====(
             <div class="form-group">
               <div class="checkbox-group">
                 <input type="checkbox" id="dst" name="dst" class="checkbox">
-                <label for="dst" class="form-label">Enable daylight saving time</label>
+                <label for="dst" class="form-label" data-i18n="lbl.dst">Enable daylight saving time</label>
               </div>
             </div>
 
-                <button type="submit" class="btn btn-primary btn-block">Save Configuration</button>
+                <button type="submit" class="btn btn-primary btn-block" data-i18n="btn.save">Save Configuration</button>
               </form>
             </div>
           </div>
@@ -376,58 +408,58 @@ const char PAGE_index[] PROGMEM = R"=====(
         <section id="mqtt-section" class="content-section">
           <div class="dashboard-grid">
             <div class="card compact-status">
-              <div class="card-title">Connection Status</div>
+              <div class="card-title" data-i18n="card.connection_status">Connection Status</div>
               <div class="status-item">
-                <div class="status-label">MQTT Connection</div>
+                <div class="status-label" data-i18n="lbl.mqtt_connection">MQTT Connection</div>
                 <div class="status-value" id="mqttconnectionstate">Checking...</div>
               </div>
             </div>
 
             <div class="card">
-              <div class="card-title">MQTT Broker Settings</div>
+              <div class="card-title" data-i18n="card.mqtt_settings">MQTT Broker Settings</div>
               <form id="mqtt-form" onsubmit="return saveMqttSettings(event)">
             <div class="form-group">
-              <label for="host" class="form-label">Broker host</label>
+              <label for="host" class="form-label" data-i18n="lbl.broker_host">Broker host</label>
               <input type="text" id="host" name="host" class="form-control" placeholder="mqtt.broker.com">
             </div>
 
             <div class="form-group">
-              <label for="port" class="form-label">Broker port</label>
+              <label for="port" class="form-label" data-i18n="lbl.broker_port">Broker port</label>
               <input type="number" id="port" name="port" class="form-control" placeholder="1883" min="1" max="65535">
             </div>
 
             <div class="form-group">
-              <label for="login" class="form-label">Username (optional)</label>
+              <label for="login" class="form-label" data-i18n="lbl.mqtt_user">Username (optional)</label>
               <input type="text" id="login" name="login" class="form-control" placeholder="Username">
             </div>
 
             <div class="form-group">
-              <label for="mqttpassword" class="form-label">Password (optional)</label>
+              <label for="mqttpassword" class="form-label" data-i18n="lbl.mqtt_password">Password (optional)</label>
               <input type="password" id="mqttpassword" name="password" class="form-control" placeholder="Password">
             </div>
 
             <div class="form-group">
-              <label for="interval" class="form-label">Publish interval</label>
+              <label for="interval" class="form-label" data-i18n="lbl.publish_interval">Publish interval</label>
               <div class="form-control-group">
                 <input type="number" id="interval" name="interval" class="form-control" placeholder="30" min="5">
-                <span>seconds</span>
+                <span data-i18n="lbl.seconds">seconds</span>
               </div>
             </div>
 
-                <button type="submit" class="btn btn-primary btn-block">Save Configuration</button>
+                <button type="submit" class="btn btn-primary btn-block" data-i18n="btn.save">Save Configuration</button>
               </form>
             </div>
 
             <div class="card">
-              <div class="card-title">MQTT Topics</div>
+              <div class="card-title" data-i18n="card.mqtt_topics">MQTT Topics</div>
 
               <div style="margin-bottom: 1.5rem;">
-                <h4 style="margin-bottom: 0.5rem; color: var(--text-primary);">Subscriber Topics</h4>
+                <h4 style="margin-bottom: 0.5rem; color: var(--text-primary);" data-i18n="lbl.sub_topics">Subscriber Topics</h4>
                 <div id="sublist" class="alert" style="font-size: 0.875rem; background: var(--surface); border-color: var(--border);">Loading...</div>
               </div>
 
               <div>
-                <h4 style="margin-bottom: 0.5rem; color: var(--text-primary);">Publisher Topics</h4>
+                <h4 style="margin-bottom: 0.5rem; color: var(--text-primary);" data-i18n="lbl.pub_topics">Publisher Topics</h4>
                 <div id="publist" class="alert" style="font-size: 0.875rem; background: var(--surface); border-color: var(--border);">Loading...</div>
               </div>
             </div>
@@ -438,66 +470,66 @@ const char PAGE_index[] PROGMEM = R"=====(
         <section id="scheduler-section" class="content-section">
           <div class="dashboard-grid">
             <div class="card">
-              <div class="card-title">Weekly Schedule</div>
+              <div class="card-title" data-i18n="card.weekly_schedule">Weekly Schedule</div>
               <div class="form-group">
                 <div class="checkbox-group">
                   <input type="checkbox" id="schedulerEnabled" class="checkbox" onchange="saveSchedulerEnabled()">
-                  <label for="schedulerEnabled" class="form-label">Enable scheduler (applies each half-hour, overrides general settings)</label>
+                  <label for="schedulerEnabled" class="form-label" data-i18n="lbl.scheduler_enable">Enable scheduler (applies each half-hour, overrides general settings)</label>
                 </div>
               </div>
-              <p style="font-size:0.8rem;color:var(--text-secondary);margin-bottom:0.75rem">Select a rule on the right, then click/drag cells to paint them. Click a painted cell again to erase it.</p>
-              <div id="schedGrid" class="sched-grid-wrap"><div class="loading">Loading...</div></div>
+              <p style="font-size:0.8rem;color:var(--text-secondary);margin-bottom:0.75rem" data-i18n="msg.sched_hint">Select a rule on the right, then click/drag cells to paint them. Click a painted cell again to erase it.</p>
+              <div id="schedGrid" class="sched-grid-wrap"><div class="loading" data-i18n="msg.loading">Loading...</div></div>
             </div>
             <div class="card sched-editor">
-              <div class="card-title">Rules</div>
+              <div class="card-title" data-i18n="card.rules">Rules</div>
               <div id="schedRulesList" style="margin-bottom:0.4rem"></div>
-              <button class="btn btn-secondary btn-block" onclick="schedAddRule()" style="margin-bottom:0.4rem">+ New rule</button>
+              <button class="btn btn-secondary btn-block" onclick="schedAddRule()" style="margin-bottom:0.4rem" data-i18n="btn.new_rule">+ New rule</button>
               <hr style="border:none;border-top:1px solid var(--border);margin-bottom:0.4rem">
               <div class="form-group">
-                <label class="form-label">Display mode</label>
+                <label class="form-label" data-i18n="lbl.display_mode">Display mode</label>
                 <select id="schedMode" class="form-control" onchange="schedEditorChange()"></select>
               </div>
               <div class="form-group">
-                <label class="form-label">Color</label>
+                <label class="form-label" data-i18n="lbl.color">Color</label>
                 <input type="color" id="schedColor" value="#ffffff" class="form-control" style="height:2rem;padding:0.1rem;cursor:pointer" onchange="schedEditorChange()">
               </div>
               <div class="form-group">
-                <label class="form-label">Color randomization</label>
+                <label class="form-label" data-i18n="lbl.color_random">Color randomization</label>
                 <select id="schedColorRandom" class="form-control" onchange="schedEditorChange()">
-                  <option value="0">No Random</option>
-                  <option value="1">Random all</option>
-                  <option value="2">Random letter</option>
-                  <option value="3">Random word</option>
+                  <option value="0" data-i18n="opt.no_random">No Random</option>
+                  <option value="1" data-i18n="opt.random_all">Random all</option>
+                  <option value="2" data-i18n="opt.random_letter">Random letter</option>
+                  <option value="3" data-i18n="opt.random_word">Random word</option>
                 </select>
               </div>
               <div class="form-group">
-                <label class="form-label">Animation</label>
+                <label class="form-label" data-i18n="lbl.animation">Animation</label>
                 <select id="schedAnimation" class="form-control" onchange="schedEditorChange()"></select>
               </div>
               <div class="form-group">
-                <label class="form-label">Speed (1=slow, 20=fast)</label>
+                <label class="form-label" data-i18n="lbl.sched_speed">Speed (1=slow, 20=fast)</label>
                 <div class="range-group">
                   <input type="range" id="schedAnimSpeed" class="range-input" min="1" max="20" step="1" oninput="document.getElementById('schedAnimSpeedT').textContent=this.value;schedEditorChange()">
                   <div class="range-value" id="schedAnimSpeedT">10</div>
                 </div>
               </div>
               <div class="form-group">
-                <label class="form-label">Min brightness (%)</label>
+                <label class="form-label" data-i18n="lbl.sched_bright_min">Min brightness (%)</label>
                 <div class="range-group">
                   <input type="range" id="schedAnimBrightMin" class="range-input" min="0" max="100" step="1" oninput="document.getElementById('schedAnimBrightMinT').textContent=this.value;schedEditorChange()">
                   <div class="range-value" id="schedAnimBrightMinT">10</div>
                 </div>
               </div>
               <div class="form-group">
-                <label class="form-label">Max brightness (%)</label>
+                <label class="form-label" data-i18n="lbl.sched_bright_max">Max brightness (%)</label>
                 <div class="range-group">
                   <input type="range" id="schedAnimBrightMax" class="range-input" min="0" max="100" step="1" oninput="document.getElementById('schedAnimBrightMaxT').textContent=this.value;schedEditorChange()">
                   <div class="range-value" id="schedAnimBrightMaxT">100</div>
                 </div>
               </div>
               <div style="display:flex;gap:0.5rem;margin-top:0.5rem">
-                <button class="btn btn-secondary" onclick="schedRaz()" style="flex:1">RAZ</button>
-                <button class="btn btn-primary" id="schedSaveBtn" onclick="saveAllScheduler()" style="flex:2">Save</button>
+                <button class="btn btn-secondary" onclick="schedRaz()" style="flex:1" data-i18n="btn.raz">RAZ</button>
+                <button class="btn btn-primary" id="schedSaveBtn" onclick="saveAllScheduler()" style="flex:2" data-i18n="btn.save">Save</button>
               </div>
             </div>
           </div>
@@ -507,21 +539,20 @@ const char PAGE_index[] PROGMEM = R"=====(
         <section id="update-section" class="content-section">
           <div class="dashboard-grid">
             <div class="card">
-              <div class="card-title">Firmware Update</div>
-              <p style="margin-bottom: 1.5rem; color: var(--text-secondary);">Upload a new firmware file to update your TexTime device.</p>
+              <div class="card-title" data-i18n="card.firmware_update">Firmware Update</div>
+              <p style="margin-bottom: 1.5rem; color: var(--text-secondary);" data-i18n="msg.firmware_desc">Upload a new firmware file to update your TexTime device.</p>
 
               <div class="alert alert-warning" style="margin-bottom: 1.5rem;">
-                <strong>Warning:</strong> Only upload firmware files specifically designed for TexTime.
-                Uploading incorrect firmware can permanently damage your device.
+                <strong data-i18n="msg.warning_label">Warning:</strong> <span data-i18n="msg.firmware_warning">Only upload firmware files specifically designed for TexTime. Uploading incorrect firmware can permanently damage your device.</span>
               </div>
 
               <form action="/update" method="post" enctype="multipart/form-data">
                 <div class="form-group">
-                  <label for="firmware" class="form-label">Select firmware file (.bin)</label>
+                  <label for="firmware" class="form-label" data-i18n="lbl.firmware_file">Select firmware file (.bin)</label>
                   <input type="file" id="firmware" name="firmware" class="form-control" accept=".bin" required>
                 </div>
 
-                <button type="submit" class="btn btn-primary btn-block">Upload Firmware</button>
+                <button type="submit" class="btn btn-primary btn-block" data-i18n="btn.upload_firmware">Upload Firmware</button>
               </form>
             </div>
           </div>
@@ -539,16 +570,268 @@ const char PAGE_index[] PROGMEM = R"=====(
   <div class="overlay" id="overlay"></div>
 
   <script>
+    // i18n dictionary
+    var I18N = {
+      0: {
+        'nav.info': 'Informations système',
+        'nav.general': 'Paramètres généraux',
+        'nav.network': 'Configuration réseau',
+        'nav.ntp': 'Configuration horaire',
+        'nav.mqtt': 'Configuration MQTT',
+        'nav.update': 'Mise à jour firmware',
+        'card.system_status': 'État du système',
+        'lbl.current_date': 'Date actuelle',
+        'lbl.uptime': 'Temps de fonctionnement',
+        'lbl.firmware_build': 'Version firmware',
+        'card.network_info': 'Informations réseau',
+        'lbl.wifi_network': 'Réseau WiFi',
+        'lbl.signal_strength': 'Force du signal',
+        'lbl.ip_address': 'Adresse IP',
+        'lbl.mac_address': 'Adresse MAC',
+        'card.sensors': 'Capteurs',
+        'lbl.ambient_light': 'Lumière ambiante',
+        'lbl.display_brightness': 'Luminosité affichage',
+        'lbl.temperature': 'Température',
+        'card.brightness': 'Contrôle de luminosité',
+        'lbl.auto_brightness': 'Luminosité automatique',
+        'lbl.brightness_sensitivity': 'Sensibilité luminosité',
+        'opt.very_high': 'Très haute',
+        'opt.high': 'Haute',
+        'opt.normal': 'Normale',
+        'opt.low': 'Faible',
+        'opt.very_low': 'Très faible',
+        'lbl.manual_brightness': 'Luminosité manuelle',
+        'lbl.day_brightness': 'Luminosité jour minimum',
+        'lbl.night_brightness': 'Luminosité nuit minimum',
+        'card.display_config': 'Configuration affichage',
+        'lbl.clock_type': "Type d'horloge",
+        'lbl.color': 'Couleur',
+        'lbl.color_random': 'Couleur aléatoire',
+        'opt.no_random': 'Aucun',
+        'opt.random_all': 'Tout aléatoire',
+        'opt.random_letter': 'Lettre aléatoire',
+        'opt.random_word': 'Mot aléatoire',
+        'lbl.language': 'Langue',
+        'lbl.display_mode': "Mode d'affichage",
+        'lbl.animation': 'Animation',
+        'lbl.anim_speed': 'Vitesse animation (1=lent, 20=rapide)',
+        'lbl.anim_bright_min': 'Luminosité min animation (%)',
+        'lbl.anim_bright_max': 'Luminosité max animation (%)',
+        'btn.save': 'Enregistrer',
+        'btn.save_restart': 'Enregistrer et redémarrer',
+        'btn.refresh_networks': 'Actualiser les réseaux',
+        'btn.upload_firmware': 'Téléverser le firmware',
+        'btn.saving': 'Enregistrement...',
+        'btn.saved': '✓ Enregistré',
+        'btn.error': '✗ Erreur',
+        'card.connection_status': 'État de connexion',
+        'lbl.current_status': 'État actuel',
+        'card.wifi_settings': 'Paramètres WiFi',
+        'lbl.ssid': 'Nom du réseau (SSID)',
+        'lbl.password': 'Mot de passe',
+        'lbl.device_name': 'Nom du dispositif',
+        'lbl.dhcp': 'Utiliser DHCP (configuration IP automatique)',
+        'lbl.subnet_mask': 'Masque de sous-réseau',
+        'lbl.gateway': 'Passerelle',
+        'lbl.dns_server': 'Serveur DNS',
+        'card.available_networks': 'Réseaux disponibles',
+        'msg.scanning': 'Recherche de réseaux...',
+        'card.ntp_settings': 'Paramètres de synchronisation horaire',
+        'lbl.ntp_server': 'Serveur NTP',
+        'lbl.update_interval': 'Intervalle de mise à jour',
+        'lbl.seconds_disabled': 'secondes (0 = désactivé)',
+        'lbl.timezone': 'Fuseau horaire',
+        'lbl.dst': "Activer l'heure d'été",
+        'lbl.mqtt_connection': 'Connexion MQTT',
+        'card.mqtt_settings': 'Paramètres du broker MQTT',
+        'lbl.broker_host': 'Hôte du broker',
+        'lbl.broker_port': 'Port du broker',
+        'lbl.mqtt_user': 'Identifiant (optionnel)',
+        'lbl.mqtt_password': 'Mot de passe (optionnel)',
+        'lbl.publish_interval': 'Intervalle de publication',
+        'lbl.seconds': 'secondes',
+        'card.mqtt_topics': 'Topics MQTT',
+        'lbl.sub_topics': 'Topics abonnés',
+        'lbl.pub_topics': 'Topics publiés',
+        'card.firmware_update': 'Mise à jour firmware',
+        'msg.firmware_desc': 'Téléversez un nouveau fichier firmware pour mettre à jour votre appareil TexTime.',
+        'msg.warning_label': 'Attention :',
+        'msg.firmware_warning': "Téléversez uniquement des fichiers firmware conçus pour TexTime. Un firmware incorrect peut endommager définitivement votre appareil.",
+        'lbl.firmware_file': 'Sélectionner le fichier firmware (.bin)',
+        'msg.loading': 'Chargement...',
+        'msg.no_networks': 'Aucun réseau trouvé',
+        'msg.network_restart': "Paramètres réseau enregistrés ! L'appareil redémarre...",
+        'status.connected': 'Connecté',
+        'status.connect': 'Connecter',
+        'status.scanning': 'Recherche...',
+        'status.disconnected': 'Déconnecté',
+        'status.connection_failed': 'Connexion échouée',
+        'status.no_network': 'Aucun réseau disponible',
+        'status.idle': 'Inactif',
+        'status.connecting': 'Connexion...',
+        'nav.scheduler': 'Programmateur',
+        'card.weekly_schedule': 'Programme hebdomadaire',
+        'lbl.scheduler_enable': "Activer le programmateur (s'applique chaque demi-heure, remplace les paramètres généraux)",
+        'msg.sched_hint': "Sélectionnez une règle à droite, puis cliquez/glissez pour peindre les cases. Recliquez une case pour l'effacer.",
+        'card.rules': 'Règles',
+        'btn.new_rule': '+ Nouvelle règle',
+        'lbl.sched_speed': 'Vitesse (1=lent, 20=rapide)',
+        'lbl.sched_bright_min': 'Luminosité min (%)',
+        'lbl.sched_bright_max': 'Luminosité max (%)',
+        'btn.raz': 'RAZ',
+        'msg.sched_raz_confirm': 'Effacer tous les créneaux ?',
+        'day.mon': 'Lun', 'day.tue': 'Mar', 'day.wed': 'Mer',
+        'day.thu': 'Jeu', 'day.fri': 'Ven', 'day.sat': 'Sam', 'day.sun': 'Dim'
+      },
+      1: {
+        'nav.info': 'System Information',
+        'nav.general': 'General Settings',
+        'nav.network': 'Network Configuration',
+        'nav.ntp': 'Time Configuration',
+        'nav.mqtt': 'MQTT Configuration',
+        'nav.update': 'Firmware Update',
+        'card.system_status': 'System Status',
+        'lbl.current_date': 'Current Date',
+        'lbl.uptime': 'Uptime',
+        'lbl.firmware_build': 'Firmware Build',
+        'card.network_info': 'Network Information',
+        'lbl.wifi_network': 'WiFi Network',
+        'lbl.signal_strength': 'Signal Strength',
+        'lbl.ip_address': 'IP Address',
+        'lbl.mac_address': 'MAC Address',
+        'card.sensors': 'Sensor Readings',
+        'lbl.ambient_light': 'Ambient Light',
+        'lbl.display_brightness': 'Display Brightness',
+        'lbl.temperature': 'Temperature',
+        'card.brightness': 'Brightness Control',
+        'lbl.auto_brightness': 'Automatic brightness',
+        'lbl.brightness_sensitivity': 'Brightness sensitivity',
+        'opt.very_high': 'Very high',
+        'opt.high': 'High',
+        'opt.normal': 'Normal',
+        'opt.low': 'Low',
+        'opt.very_low': 'Very low',
+        'lbl.manual_brightness': 'Manual brightness',
+        'lbl.day_brightness': 'Minimum day brightness',
+        'lbl.night_brightness': 'Minimum night brightness',
+        'card.display_config': 'Display Configuration',
+        'lbl.clock_type': 'Clock type',
+        'lbl.color': 'Color',
+        'lbl.color_random': 'Color randomization',
+        'opt.no_random': 'No Random',
+        'opt.random_all': 'Random all',
+        'opt.random_letter': 'Random letter',
+        'opt.random_word': 'Random word',
+        'lbl.language': 'Language',
+        'lbl.display_mode': 'Display mode',
+        'lbl.animation': 'Animation',
+        'lbl.anim_speed': 'Animation speed (1=slow, 20=fast)',
+        'lbl.anim_bright_min': 'Animation min brightness (%)',
+        'lbl.anim_bright_max': 'Animation max brightness (%)',
+        'btn.save': 'Save Configuration',
+        'btn.save_restart': 'Save & Restart',
+        'btn.refresh_networks': 'Refresh Networks',
+        'btn.upload_firmware': 'Upload Firmware',
+        'btn.saving': 'Saving...',
+        'btn.saved': '✓ Saved',
+        'btn.error': '✗ Error',
+        'card.connection_status': 'Connection Status',
+        'lbl.current_status': 'Current Status',
+        'card.wifi_settings': 'WiFi Settings',
+        'lbl.ssid': 'Network name (SSID)',
+        'lbl.password': 'Password',
+        'lbl.device_name': 'Device name',
+        'lbl.dhcp': 'Use DHCP (automatic IP configuration)',
+        'lbl.subnet_mask': 'Subnet Mask',
+        'lbl.gateway': 'Gateway',
+        'lbl.dns_server': 'DNS Server',
+        'card.available_networks': 'Available Networks',
+        'msg.scanning': 'Scanning for networks...',
+        'card.ntp_settings': 'Time Synchronization Settings',
+        'lbl.ntp_server': 'NTP Server',
+        'lbl.update_interval': 'Update interval',
+        'lbl.seconds_disabled': 'seconds (0 = disabled)',
+        'lbl.timezone': 'Timezone',
+        'lbl.dst': 'Enable daylight saving time',
+        'lbl.mqtt_connection': 'MQTT Connection',
+        'card.mqtt_settings': 'MQTT Broker Settings',
+        'lbl.broker_host': 'Broker host',
+        'lbl.broker_port': 'Broker port',
+        'lbl.mqtt_user': 'Username (optional)',
+        'lbl.mqtt_password': 'Password (optional)',
+        'lbl.publish_interval': 'Publish interval',
+        'lbl.seconds': 'seconds',
+        'card.mqtt_topics': 'MQTT Topics',
+        'lbl.sub_topics': 'Subscriber Topics',
+        'lbl.pub_topics': 'Publisher Topics',
+        'card.firmware_update': 'Firmware Update',
+        'msg.firmware_desc': 'Upload a new firmware file to update your TexTime device.',
+        'msg.warning_label': 'Warning:',
+        'msg.firmware_warning': 'Only upload firmware files specifically designed for TexTime. Uploading incorrect firmware can permanently damage your device.',
+        'lbl.firmware_file': 'Select firmware file (.bin)',
+        'msg.loading': 'Loading...',
+        'msg.no_networks': 'No networks found',
+        'msg.network_restart': 'Network settings saved! Device is restarting...',
+        'status.connected': 'Connected',
+        'status.connect': 'Connect',
+        'status.scanning': 'Scanning...',
+        'status.disconnected': 'Disconnected',
+        'status.connection_failed': 'Connection Failed',
+        'status.no_network': 'No Network Available',
+        'status.idle': 'Idle',
+        'status.connecting': 'Connecting...',
+        'nav.scheduler': 'Scheduler',
+        'card.weekly_schedule': 'Weekly Schedule',
+        'lbl.scheduler_enable': 'Enable scheduler (applies each half-hour, overrides general settings)',
+        'msg.sched_hint': 'Select a rule on the right, then click/drag cells to paint them. Click a painted cell again to erase it.',
+        'card.rules': 'Rules',
+        'btn.new_rule': '+ New rule',
+        'lbl.sched_speed': 'Speed (1=slow, 20=fast)',
+        'lbl.sched_bright_min': 'Min brightness (%)',
+        'lbl.sched_bright_max': 'Max brightness (%)',
+        'btn.raz': 'RAZ',
+        'msg.sched_raz_confirm': 'Clear all scheduled slots?',
+        'day.mon': 'Mon', 'day.tue': 'Tue', 'day.wed': 'Wed',
+        'day.thu': 'Thu', 'day.fri': 'Fri', 'day.sat': 'Sat', 'day.sun': 'Sun'
+      }
+    };
+
+    var currentLang = 0;
+
+    function T(key) {
+      var dict = I18N[currentLang] || I18N[0];
+      return dict[key] || key;
+    }
+
+    function applyI18n() {
+      document.querySelectorAll('[data-i18n]').forEach(function(el) {
+        el.textContent = T(el.dataset.i18n);
+      });
+      document.getElementById('sectionTitle').textContent = T('nav.' + currentSection);
+    }
+
+    function initI18n() {
+      return fetch('/admin/langvalue')
+        .then(function(r) { return r.text(); })
+        .then(function(v) {
+          currentLang = parseInt(v) || 0;
+          applyI18n();
+        })
+        .catch(function() {
+          applyI18n();
+        });
+    }
+
     // Initialize color picker
     function initColorPicker() {
-      const colorInput = document.getElementById('color');
-      const colorText = document.getElementById('colorText');
+      var colorInput = document.getElementById('color');
+      var colorText = document.getElementById('colorText');
 
       if (colorInput && colorText) {
         function syncTextToColorPicker() {
-          const currentColorValue = colorText.value;
+          var currentColorValue = colorText.value;
           if (currentColorValue) {
-            let value = currentColorValue.trim();
+            var value = currentColorValue.trim();
             if (!value.startsWith('#')) value = '#' + value;
             if (isValidHexColor(value)) {
               colorInput.value = value;
@@ -556,50 +839,37 @@ const char PAGE_index[] PROGMEM = R"=====(
           }
         }
 
-        // Sync color picker to text input
         colorInput.addEventListener('input', function(e) {
           colorText.value = e.target.value;
           updatecolor(e.target.value);
         });
 
-        // Sync text input to color picker
         colorText.addEventListener('input', function(e) {
           syncTextToColorPicker();
-          let value = e.target.value.trim();
+          var value = e.target.value.trim();
           if (!value.startsWith('#')) value = '#' + value;
           if (isValidHexColor(value)) {
             updatecolor(value);
           }
         });
 
-        // Sync on load
         setTimeout(syncTextToColorPicker, 100);
         setTimeout(syncTextToColorPicker, 500);
       }
     }
 
     // Dashboard Management
-    let currentSection = 'info';
-    let updateIntervals = {};
-
-    // Section titles mapping
-    const sectionTitles = {
-      'info': 'System Information',
-      'general': 'General Settings',
-      'network': 'Network Configuration',
-      'ntp': 'Time Configuration',
-      'mqtt': 'MQTT Configuration',
-      'update': 'Firmware Update',
-      'scheduler': 'Display Scheduler'
-    };
+    var currentSection = 'info';
+    var updateIntervals = {};
 
     // Utility functions
     function debounce(func, wait) {
-      let timeout;
-      return function executedFunction(...args) {
-        const later = () => {
+      var timeout;
+      return function executedFunction() {
+        var args = arguments;
+        var later = function() {
           clearTimeout(timeout);
-          func(...args);
+          func.apply(this, args);
         };
         clearTimeout(timeout);
         timeout = setTimeout(later, wait);
@@ -608,22 +878,19 @@ const char PAGE_index[] PROGMEM = R"=====(
 
     // Navigation Management
     function switchSection(sectionName) {
-      // Update navigation
-      document.querySelectorAll('.nav-item').forEach(btn => {
+      document.querySelectorAll('.nav-item').forEach(function(btn) {
         btn.classList.remove('active');
       });
-      document.querySelector(`[data-section="${sectionName}"]`).classList.add('active');
+      var navBtn = document.querySelector('[data-section="' + sectionName + '"]');
+      if (navBtn) navBtn.classList.add('active');
 
-      // Update content
-      document.querySelectorAll('.content-section').forEach(section => {
+      document.querySelectorAll('.content-section').forEach(function(section) {
         section.classList.remove('active');
       });
-      document.getElementById(`${sectionName}-section`).classList.add('active');
+      document.getElementById(sectionName + '-section').classList.add('active');
 
-      // Update header title
-      document.getElementById('sectionTitle').textContent = sectionTitles[sectionName] || 'Dashboard';
+      document.getElementById('sectionTitle').textContent = T('nav.' + sectionName);
 
-      // Stop previous section updates
       if (updateIntervals[currentSection]) {
         clearInterval(updateIntervals[currentSection]);
         delete updateIntervals[currentSection];
@@ -631,34 +898,29 @@ const char PAGE_index[] PROGMEM = R"=====(
 
       currentSection = sectionName;
 
-      // Load section-specific data
       loadSectionData(sectionName);
-
-      // Close mobile menu
       closeMobileMenu();
     }
 
     // Mobile menu functions
     function toggleMobileMenu() {
-      const sidebar = document.getElementById('sidebar');
-      const overlay = document.getElementById('overlay');
-
+      var sidebar = document.getElementById('sidebar');
+      var overlay = document.getElementById('overlay');
       sidebar.classList.toggle('open');
       overlay.classList.toggle('active');
     }
 
     function closeMobileMenu() {
-      const sidebar = document.getElementById('sidebar');
-      const overlay = document.getElementById('overlay');
-
+      var sidebar = document.getElementById('sidebar');
+      var overlay = document.getElementById('overlay');
       sidebar.classList.remove('open');
       overlay.classList.remove('active');
     }
 
     // Theme toggle
     function toggleTheme() {
-      const html = document.documentElement;
-      const themeToggle = document.getElementById('themeToggle');
+      var html = document.documentElement;
+      var themeToggle = document.getElementById('themeToggle');
 
       if (html.getAttribute('data-theme') === 'dark') {
         html.setAttribute('data-theme', 'light');
@@ -671,25 +933,24 @@ const char PAGE_index[] PROGMEM = R"=====(
       }
     }
 
-    // Load saved theme
     function loadTheme() {
-      const savedTheme = localStorage.getItem('theme') || 'light';
-      const html = document.documentElement;
-      const themeToggle = document.getElementById('themeToggle');
+      var savedTheme = localStorage.getItem('theme') || 'light';
+      var html = document.documentElement;
+      var themeToggle = document.getElementById('themeToggle');
 
       html.setAttribute('data-theme', savedTheme);
       themeToggle.textContent = savedTheme === 'dark' ? '☀️' : '🌙';
     }
 
     function showLoading(elementId) {
-      const element = document.getElementById(elementId);
+      var element = document.getElementById(elementId);
       if (element) {
-        element.innerHTML = '<div class="loading">Loading...</div>';
+        element.innerHTML = '<div class="loading">' + T('msg.loading') + '</div>';
       }
     }
 
     function hideLoading(elementId) {
-      const element = document.getElementById(elementId);
+      var element = document.getElementById(elementId);
       if (element && element.querySelector('.loading')) {
         element.innerHTML = '';
       }
@@ -698,91 +959,75 @@ const char PAGE_index[] PROGMEM = R"=====(
     // Load data for specific section
     function loadSectionData(sectionName) {
       switch(sectionName) {
-        case 'info':
-          loadSystemInfo();
-          break;
-        case 'general':
-          loadGeneralSettings();
-          break;
-        case 'network':
-          loadNetworkSettings();
-          break;
-        case 'ntp':
-          loadNtpSettings();
-          break;
-        case 'mqtt':
-          loadMqttSettings();
-          break;
-        case 'scheduler':
-          loadSchedulerSettings();
-          break;
+        case 'info':    loadSystemInfo();     break;
+        case 'general': loadGeneralSettings(); break;
+        case 'network': loadNetworkSettings(); break;
+        case 'ntp':     loadNtpSettings();     break;
+        case 'mqtt':      loadMqttSettings();      break;
+        case 'scheduler': loadSchedulerSettings(); break;
       }
     }
 
-    // Network display improvements
+    // Network display
     function displayNetworks(networks) {
-      const networksContainer = document.getElementById('networks');
+      var networksContainer = document.getElementById('networks');
       if (!networks || networks.length === 0) {
-        networksContainer.innerHTML = '<div class="loading">No networks found</div>';
+        networksContainer.innerHTML = '<div class="loading">' + T('msg.no_networks') + '</div>';
         return;
       }
 
-      // Remove duplicates based on SSID
-      const uniqueNetworks = networks.filter((network, index, self) =>
-        index === self.findIndex(n => n.ssid === network.ssid)
-      );
+      var uniqueNetworks = networks.filter(function(network, index, self) {
+        return index === self.findIndex(function(n) { return n.ssid === network.ssid; });
+      });
 
-      const networksHTML = uniqueNetworks.map(network => {
-        const signalBars = getSignalBars(network.rssi);
-        const isConnected = network.connected || false;
-        const security = network.security || 'Open';
+      var networksHTML = uniqueNetworks.map(function(network) {
+        var signalBars = getSignalBars(network.rssi);
+        var isConnected = network.connected || false;
+        var security = network.security || 'Open';
 
-        return `
-          <div class="network-item ${isConnected ? 'connected' : ''}" onclick="selssid('${network.ssid}')">
-            <div class="network-info">
-              <div class="network-name">${network.ssid}</div>
-              <div class="network-details">
-                <div class="network-signal">
-                  <div class="signal-bars">${signalBars}</div>
-                  <span>${network.rssi}%</span>
-                </div>
-                <div class="network-security">
-                  <span class="security-icon">${security === 'Open' ? '🔓' : '🔒'}</span>
-                  <span>${security}</span>
-                </div>
-              </div>
-            </div>
-            <div class="network-actions">
-              ${isConnected ?
-                '<span class="connected-badge">Connected</span>' :
-                '<button class="connect-btn" onclick="event.stopPropagation(); selssid(\'${network.ssid}\')">Connect</button>'
-              }
-            </div>
-          </div>
-        `;
+        return '<div class="network-item ' + (isConnected ? 'connected' : '') + '" onclick="selssid(\'' + network.ssid + '\')">' +
+          '<div class="network-info">' +
+            '<div class="network-name">' + network.ssid + '</div>' +
+            '<div class="network-details">' +
+              '<div class="network-signal">' +
+                '<div class="signal-bars">' + signalBars + '</div>' +
+                '<span>' + network.rssi + '%</span>' +
+              '</div>' +
+              '<div class="network-security">' +
+                '<span class="security-icon">' + (security === 'Open' ? '🔓' : '🔒') + '</span>' +
+                '<span>' + security + '</span>' +
+              '</div>' +
+            '</div>' +
+          '</div>' +
+          '<div class="network-actions">' +
+            (isConnected ?
+              '<span class="connected-badge">' + T('status.connected') + '</span>' :
+              '<button class="connect-btn" onclick="event.stopPropagation(); selssid(\'' + network.ssid + '\')">' + T('status.connect') + '</button>'
+            ) +
+          '</div>' +
+        '</div>';
       }).join('');
 
       networksContainer.innerHTML = networksHTML;
     }
 
     function getSignalBars(rssi) {
-      const strength = Math.max(0, Math.min(100, rssi));
-      const bars = Math.ceil(strength / 20);
+      var strength = Math.max(0, Math.min(100, rssi));
+      var bars = Math.ceil(strength / 20);
 
-      return Array.from({length: 5}, (_, i) =>
-        `<div class="signal-bar ${i < bars ? 'active' : ''}"></div>`
-      ).join('');
+      return Array.from({length: 5}, function(_, i) {
+        return '<div class="signal-bar ' + (i < bars ? 'active' : '') + '"></div>';
+      }).join('');
     }
 
-    // Fix dropdown duplicates
     function removeDuplicateOptions(selectElement) {
-      const options = Array.from(selectElement.options);
-      const uniqueOptions = options.filter((option, index, self) =>
-        index === self.findIndex(o => o.value === option.value)
-      );
+      var options = Array.from(selectElement.options);
+      var uniqueOptions = options.filter(function(option, index, self) {
+        return index === self.findIndex(function(o) { return o.value === option.value; });
+      });
 
       selectElement.innerHTML = '';
-      uniqueOptions.forEach(option => selectElement.appendChild(option));
+      uniqueOptions.forEach(function(option) { selectElement.appendChild(option); });
     }
 
     // System Info functions
@@ -796,40 +1041,46 @@ const char PAGE_index[] PROGMEM = R"=====(
     }
 
     // General Settings functions
-    const debouncedUpdate = debounce((param, value) => {
-      setValues(`/admin/led?${param}=${value}`);
+    var debouncedUpdate = debounce(function(param, value) {
+      setValues('/admin/led?' + param + '=' + value);
     }, 300);
 
     function updatebrightness() {
-      const value = document.getElementById("brightness").value;
+      var value = document.getElementById("brightness").value;
       document.getElementById("brightnesst").textContent = value;
       debouncedUpdate("brightness", value);
     }
 
     function updatebrightnessday() {
-      const value = document.getElementById("brightnessday").value;
+      var value = document.getElementById("brightnessday").value;
       document.getElementById("brightnessdayt").textContent = value;
       debouncedUpdate("brightnessday", value);
     }
 
     function updatebrightnessnight() {
-      const value = document.getElementById("brightnessnight").value;
+      var value = document.getElementById("brightnessnight").value;
       document.getElementById("brightnessnightt").textContent = value;
       debouncedUpdate("brightnessnight", value);
     }
 
     function updatecolor(colorValue) {
-      // Remove # if present for API call
-      const cleanColor = colorValue.replace('#', '');
+      var cleanColor = colorValue.replace('#', '');
       debouncedUpdate("color", cleanColor);
     }
 
     function initializeColorPicker() {
       initColorPicker();
+      var colorInput = document.getElementById('color');
+      var colorText  = document.getElementById('colorText');
+      if (colorInput && colorText && colorText.value) {
+        var v = colorText.value.trim();
+        if (!v.startsWith('#')) v = '#' + v;
+        if (isValidHexColor(v)) colorInput.value = v;
+      }
     }
 
     function hexToRgb(hex) {
-      const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+      var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
       return result ? {
         r: parseInt(result[1], 16),
         g: parseInt(result[2], 16),
@@ -846,7 +1097,9 @@ const char PAGE_index[] PROGMEM = R"=====(
     }
 
     function updatelang() {
-      setValues("/admin/led?lang=" + document.getElementById("lang").value);
+      currentLang = parseInt(document.getElementById("lang").value);
+      applyI18n();
+      setValues("/admin/led?lang=" + currentLang);
     }
 
     function updatemode() {
@@ -857,8 +1110,26 @@ const char PAGE_index[] PROGMEM = R"=====(
       setValues("/admin/led?animation=" + document.getElementById("animation").value);
     }
 
+    function updateanimspeed() {
+      var value = document.getElementById("animspeed").value;
+      document.getElementById("animspeedt").textContent = value;
+      debouncedUpdate("animspeed", value);
+    }
+
+    function updateanimbrightmin() {
+      var value = document.getElementById("animbrightmin").value;
+      document.getElementById("animbrightmint").textContent = value;
+      debouncedUpdate("animbrightmin", value);
+    }
+
+    function updateanimbrightmax() {
+      var value = document.getElementById("animbrightmax").value;
+      document.getElementById("animbrightmaxt").textContent = value;
+      debouncedUpdate("animbrightmax", value);
+    }
+
     function validatebrightnessauto() {
-      const isAuto = document.getElementById('brightnessauto').checked;
+      var isAuto = document.getElementById('brightnessauto').checked;
 
       document.getElementById("brightness").disabled = isAuto;
       document.getElementById("brightnessday").disabled = !isAuto;
@@ -883,40 +1154,32 @@ const char PAGE_index[] PROGMEM = R"=====(
       }
     }
 
-    // Utility function for save button feedback
     function setSaveButtonState(button, state) {
-      if (!button) {
-        return;
-      }
+      if (!button) return;
 
-      // Store original text if not already stored
-      if (!button.dataset.originalText) {
-        button.dataset.originalText = button.textContent;
-      }
-      const originalText = button.dataset.originalText;
-
+      var i18nKey = button.dataset.i18n;
       button.disabled = true;
 
       if (state === 'saving') {
-        button.textContent = 'Saving...';
+        button.textContent = T('btn.saving');
         button.style.backgroundColor = '#ffa500';
         button.style.color = 'white';
       } else if (state === 'success') {
-        button.textContent = '✓ Saved';
+        button.textContent = T('btn.saved');
         button.style.backgroundColor = '#28a745';
         button.style.color = 'white';
-        setTimeout(() => {
-          button.textContent = originalText;
+        setTimeout(function() {
+          button.textContent = i18nKey ? T(i18nKey) : T('btn.save');
           button.style.backgroundColor = '';
           button.style.color = '';
           button.disabled = false;
         }, 3000);
       } else if (state === 'error') {
-        button.textContent = '✗ Error';
+        button.textContent = T('btn.error');
         button.style.backgroundColor = '#dc3545';
         button.style.color = 'white';
-        setTimeout(() => {
-          button.textContent = originalText;
+        setTimeout(function() {
+          button.textContent = i18nKey ? T(i18nKey) : T('btn.save');
           button.style.backgroundColor = '';
           button.style.color = '';
           button.disabled = false;
@@ -926,9 +1189,9 @@ const char PAGE_index[] PROGMEM = R"=====(
 
     function saveGeneralSettings(event) {
       event.preventDefault();
-      const form = event.target;
-      const button = form.querySelector('button[type="submit"]') || form.querySelector('button') || event.submitter;
-      const formData = new FormData(form);
+      var form = event.target;
+      var button = form.querySelector('button[type="submit"]') || form.querySelector('button') || event.submitter;
+      var formData = new FormData(form);
 
       setSaveButtonState(button, 'saving');
 
@@ -936,16 +1199,15 @@ const char PAGE_index[] PROGMEM = R"=====(
         method: 'POST',
         body: formData
       })
-      .then(response => {
+      .then(function(response) {
         if (response.ok) {
           setSaveButtonState(button, 'success');
-          // Reload values to reflect changes
           loadGeneralSettings();
         } else {
           setSaveButtonState(button, 'error');
         }
       })
-      .catch(error => {
+      .catch(function() {
         setSaveButtonState(button, 'error');
       });
 
@@ -955,19 +1217,18 @@ const char PAGE_index[] PROGMEM = R"=====(
     // Network Settings functions
     function loadNetworkSettings() {
       setValues("/admin/networkfieldsvalues")
-        .then(() => {
+        .then(function() {
           validateNetworkSettings();
           return refreshNetworks();
         })
-        .then(() => {
-          // Initial network status update
+        .then(function() {
           updateNetworkConnectionStatus();
         });
     }
 
     function validateNetworkSettings() {
-      const isDHCP = document.getElementById('dhcp').checked;
-      const staticConfig = document.getElementById('static-config');
+      var isDHCP = document.getElementById('dhcp').checked;
+      var staticConfig = document.getElementById('static-config');
 
       if (isDHCP) {
         staticConfig.style.opacity = '0.5';
@@ -977,57 +1238,52 @@ const char PAGE_index[] PROGMEM = R"=====(
         staticConfig.style.pointerEvents = 'auto';
       }
 
-      ['ipaddress', 'netmask', 'gateway', 'dnsserver'].forEach(id => {
-        const element = document.getElementById(id);
-        if (element) {
-          element.disabled = isDHCP;
-        }
+      ['ipaddress', 'netmask', 'gateway', 'dnsserver'].forEach(function(id) {
+        var element = document.getElementById(id);
+        if (element) element.disabled = isDHCP;
       });
     }
 
     function refreshNetworks() {
       showLoading('networks');
       return setValues("/admin/networkconnectionvalues")
-        .then(() => {
+        .then(function() {
           hideLoading('networks');
-          // Update network connection status display
           updateNetworkConnectionStatus();
         })
-        .catch(error => {
+        .catch(function(error) {
           console.error('Failed to get network state:', error);
           document.getElementById('networks').innerHTML = '<div class="alert alert-error">Failed to scan networks</div>';
         });
     }
 
     function updateNetworkConnectionStatus() {
-      const connectionStateRaw = document.getElementById('connectionstate');
-      const connectionStateDisplay = document.getElementById('connectionstatedisplay');
+      var connectionStateRaw = document.getElementById('connectionstate');
+      var connectionStateDisplay = document.getElementById('connectionstatedisplay');
 
       if (connectionStateRaw && connectionStateDisplay && connectionStateRaw.textContent) {
-        const status = connectionStateRaw.textContent.trim();
+        var status = connectionStateRaw.textContent.trim();
 
-        // Remove existing status classes from display element
         connectionStateDisplay.classList.remove('connected', 'connecting', 'disconnected');
 
-        // Add appropriate status class and update display (keeping raw data intact)
         if (status === 'CONNECTED') {
           connectionStateDisplay.classList.add('status-indicator', 'connected');
-          connectionStateDisplay.innerHTML = '✅ Connected';
+          connectionStateDisplay.innerHTML = '✅ ' + T('status.connected');
         } else if (status === 'SCAN COMPLETED' || status === 'Checking...') {
           connectionStateDisplay.classList.add('status-indicator', 'connecting');
-          connectionStateDisplay.innerHTML = '🔍 Scanning...';
+          connectionStateDisplay.innerHTML = '🔍 ' + T('status.scanning');
         } else if (status === 'DISCONNECTED' || status === 'CONNECTION LOST') {
           connectionStateDisplay.classList.add('status-indicator', 'disconnected');
-          connectionStateDisplay.innerHTML = '❌ Disconnected';
+          connectionStateDisplay.innerHTML = '❌ ' + T('status.disconnected');
         } else if (status === 'CONNECT FAILED') {
           connectionStateDisplay.classList.add('status-indicator', 'disconnected');
-          connectionStateDisplay.innerHTML = '⚠️ Connection Failed';
+          connectionStateDisplay.innerHTML = '⚠️ ' + T('status.connection_failed');
         } else if (status === 'NO SSID AVAILBLE') {
           connectionStateDisplay.classList.add('status-indicator', 'disconnected');
-          connectionStateDisplay.innerHTML = '📡 No Network Available';
+          connectionStateDisplay.innerHTML = '📡 ' + T('status.no_network');
         } else if (status === 'Idle') {
           connectionStateDisplay.classList.add('status-indicator', 'connecting');
-          connectionStateDisplay.innerHTML = '⏳ Idle';
+          connectionStateDisplay.innerHTML = '⏳ ' + T('status.idle');
         } else {
           connectionStateDisplay.classList.add('status-indicator', 'disconnected');
           connectionStateDisplay.innerHTML = '🔄 ' + status;
@@ -1037,19 +1293,23 @@ const char PAGE_index[] PROGMEM = R"=====(
 
     function loadGeneralSettings() {
       setValues("/admin/generalledconfigvalues")
-        .then(() => setValues("/admin/generallangsvalues"))
-        .then(() => setValues("/admin/generalmodesvalues"))
-        .then(() => setValues("/admin/generalanimationsvalues"))
-        .then(() => setValues("/admin/generalfieldsvalues"))
-        .then(() => {
+        .then(function() { return setValues("/admin/generallangsvalues"); })
+        .then(function() { return setValues("/admin/generalmodesvalues"); })
+        .then(function() { return setValues("/admin/generalanimationsvalues"); })
+        .then(function() { return setValues("/admin/generalfieldsvalues"); })
+        .then(function() {
           validatebrightnessauto();
-          // Remove duplicates from dropdowns
           removeDuplicateOptions(document.getElementById('ledconfig'));
           removeDuplicateOptions(document.getElementById('lang'));
           removeDuplicateOptions(document.getElementById('mode'));
           removeDuplicateOptions(document.getElementById('animation'));
-          // Initialize color picker after values are loaded
           initializeColorPicker();
+          // Sync language from loaded value and re-apply translations
+          var langEl = document.getElementById('lang');
+          if (langEl && langEl.value !== '') {
+            currentLang = parseInt(langEl.value);
+            applyI18n();
+          }
         });
     }
 
@@ -1059,9 +1319,9 @@ const char PAGE_index[] PROGMEM = R"=====(
 
     function saveNetworkSettings(event) {
       event.preventDefault();
-      const form = event.target;
-      const button = form.querySelector('button[type="submit"]') || form.querySelector('button') || event.submitter;
-      const formData = new FormData(form);
+      var form = event.target;
+      var button = form.querySelector('button[type="submit"]') || form.querySelector('button') || event.submitter;
+      var formData = new FormData(form);
 
       setSaveButtonState(button, 'saving');
 
@@ -1069,18 +1329,17 @@ const char PAGE_index[] PROGMEM = R"=====(
         method: 'POST',
         body: formData
       })
-      .then(response => {
+      .then(function(response) {
         if (response.ok) {
           setSaveButtonState(button, 'success');
-          // Network settings save triggers ESP restart, so show success and warn user
-          setTimeout(() => {
-            alert('Network settings saved! Device is restarting...');
+          setTimeout(function() {
+            alert(T('msg.network_restart'));
           }, 1000);
         } else {
           setSaveButtonState(button, 'error');
         }
       })
-      .catch(error => {
+      .catch(function() {
         setSaveButtonState(button, 'error');
       });
 
@@ -1094,9 +1353,9 @@ const char PAGE_index[] PROGMEM = R"=====(
 
     function saveNtpSettings(event) {
       event.preventDefault();
-      const form = event.target;
-      const button = form.querySelector('button[type="submit"]') || form.querySelector('button') || event.submitter;
-      const formData = new FormData(form);
+      var form = event.target;
+      var button = form.querySelector('button[type="submit"]') || form.querySelector('button') || event.submitter;
+      var formData = new FormData(form);
 
       setSaveButtonState(button, 'saving');
 
@@ -1104,16 +1363,15 @@ const char PAGE_index[] PROGMEM = R"=====(
         method: 'POST',
         body: formData
       })
-      .then(response => {
+      .then(function(response) {
         if (response.ok) {
           setSaveButtonState(button, 'success');
-          // Reload values to reflect changes
           loadNtpSettings();
         } else {
           setSaveButtonState(button, 'error');
         }
       })
-      .catch(error => {
+      .catch(function() {
         setSaveButtonState(button, 'error');
       });
 
@@ -1123,7 +1381,7 @@ const char PAGE_index[] PROGMEM = R"=====(
     // MQTT Settings functions
     function loadMqttSettings() {
       setValues("/admin/mqttfieldsvalues")
-        .then(() => {
+        .then(function() {
           getMqttState();
           updateIntervals.mqtt = setInterval(getMqttState, 3000);
         });
@@ -1131,27 +1389,24 @@ const char PAGE_index[] PROGMEM = R"=====(
 
     function getMqttState() {
       setValuesHighPriority("/admin/mqttconnectionvalues")
-        .then(() => {
-          // Update MQTT connection status display with visual indicator
+        .then(function() {
           updateMqttConnectionStatus();
         });
     }
 
     function updateMqttConnectionStatus() {
-      const connectionState = document.getElementById('mqttconnectionstate');
+      var connectionState = document.getElementById('mqttconnectionstate');
       if (connectionState && connectionState.textContent) {
-        const status = connectionState.textContent.trim();
+        var status = connectionState.textContent.trim();
 
-        // Remove existing status classes
         connectionState.classList.remove('connected', 'connecting', 'disconnected');
 
-        // Add appropriate status class and update display
         if (status === 'MQTT_CONNECTED') {
           connectionState.classList.add('status-indicator', 'connected');
-          connectionState.innerHTML = '✅ Connected';
+          connectionState.innerHTML = '✅ ' + T('status.connected');
         } else if (status.includes('CONNECTING') || status === 'Checking...') {
           connectionState.classList.add('status-indicator', 'connecting');
-          connectionState.innerHTML = '🔄 Connecting...';
+          connectionState.innerHTML = '🔄 ' + T('status.connecting');
         } else {
           connectionState.classList.add('status-indicator', 'disconnected');
           connectionState.innerHTML = '❌ ' + status.replace('MQTT_', '').replace('_', ' ');
@@ -1161,9 +1416,9 @@ const char PAGE_index[] PROGMEM = R"=====(
 
     function saveMqttSettings(event) {
       event.preventDefault();
-      const form = event.target;
-      const button = form.querySelector('button[type="submit"]') || form.querySelector('button') || event.submitter;
-      const formData = new FormData(form);
+      var form = event.target;
+      var button = form.querySelector('button[type="submit"]') || form.querySelector('button') || event.submitter;
+      var formData = new FormData(form);
 
       setSaveButtonState(button, 'saving');
 
@@ -1171,16 +1426,15 @@ const char PAGE_index[] PROGMEM = R"=====(
         method: 'POST',
         body: formData
       })
-      .then(response => {
+      .then(function(response) {
         if (response.ok) {
           setSaveButtonState(button, 'success');
-          // Reload values to reflect changes
           loadMqttSettings();
         } else {
           setSaveButtonState(button, 'error');
         }
       })
-      .catch(error => {
+      .catch(function() {
         setSaveButtonState(button, 'error');
       });
 
@@ -1190,20 +1444,20 @@ const char PAGE_index[] PROGMEM = R"=====(
     // Load function
     function load(src, type, callback) {
       if (type === 'js') {
-        const script = document.createElement('script');
+        var script = document.createElement('script');
         script.src = src;
         script.type = 'text/javascript';
         script.async = false;
-        script.onload = () => callback && callback();
-        script.onerror = () => console.error(`Failed to load script: ${src}`);
+        script.onload = function() { callback && callback(); };
+        script.onerror = function() { console.error('Failed to load script: ' + src); };
         document.head.appendChild(script);
       } else if (type === 'css') {
-        const link = document.createElement('link');
+        var link = document.createElement('link');
         link.href = src;
         link.rel = 'stylesheet';
         link.type = 'text/css';
-        link.onload = () => callback && callback();
-        link.onerror = () => console.error(`Failed to load stylesheet: ${src}`);
+        link.onload = function() { callback && callback(); };
+        link.onerror = function() { console.error('Failed to load stylesheet: ' + src); };
         document.head.appendChild(link);
       }
     }
@@ -1211,49 +1465,39 @@ const char PAGE_index[] PROGMEM = R"=====(
     // Initialize app
     window.onload = function() {
       load("style.css", "css", function() {
-        // Load saved theme
         loadTheme();
 
-        // Setup navigation
-        document.querySelectorAll('.nav-item').forEach(btn => {
-          btn.addEventListener('click', () => {
+        document.querySelectorAll('.nav-item').forEach(function(btn) {
+          btn.addEventListener('click', function() {
             switchSection(btn.dataset.section);
           });
         });
 
-        // Setup mobile menu
-        const menuToggle = document.getElementById('menuToggle');
-        const overlay = document.getElementById('overlay');
-        const themeToggle = document.getElementById('themeToggle');
+        var menuToggle = document.getElementById('menuToggle');
+        var overlay = document.getElementById('overlay');
+        var themeToggle = document.getElementById('themeToggle');
 
         menuToggle.addEventListener('click', toggleMobileMenu);
         overlay.addEventListener('click', closeMobileMenu);
         themeToggle.addEventListener('click', toggleTheme);
 
-        // Load initial section
+        initI18n();
         loadSectionData(currentSection);
-
-        // Initialize color picker
         initializeColorPicker();
-
-        // Set initial header title
-        document.getElementById('sectionTitle').textContent = sectionTitles[currentSection] || 'Dashboard';
 
         console.log("TexTime dashboard loaded");
       });
     }
 
-    // Cleanup intervals when leaving page
-    window.addEventListener('beforeunload', () => {
-      Object.values(updateIntervals).forEach(interval => {
+    window.addEventListener('beforeunload', function() {
+      Object.values(updateIntervals).forEach(function(interval) {
         clearInterval(interval);
       });
     });
 
-    // Handle visibility change to pause/resume updates
     window.addEventListener('visibilitychange', function() {
       if (document.hidden) {
-        Object.values(updateIntervals).forEach(interval => {
+        Object.values(updateIntervals).forEach(function(interval) {
           clearInterval(interval);
         });
         updateIntervals = {};
@@ -1262,14 +1506,12 @@ const char PAGE_index[] PROGMEM = R"=====(
       }
     });
 
-    // Handle escape key to close mobile menu
     document.addEventListener('keydown', function(event) {
       if (event.key === 'Escape') {
         closeMobileMenu();
       }
     });
 
-    // Handle window resize
     window.addEventListener('resize', function() {
       if (window.innerWidth >= 1024) {
         closeMobileMenu();
@@ -1366,7 +1608,7 @@ const char PAGE_index[] PROGMEM = R"=====(
     }
 
     function renderSchedulerGrid() {
-      var days=['Mon','Tue','Wed','Thu','Fri','Sat','Sun'];
+      var days=[T('day.mon'),T('day.tue'),T('day.wed'),T('day.thu'),T('day.fri'),T('day.sat'),T('day.sun')];
       var html='<table class="sched-table"><thead><tr><th></th>';
       days.forEach(function(d){html+='<th>'+d+'</th>';});
       html+='</tr></thead><tbody>';
@@ -1448,7 +1690,7 @@ const char PAGE_index[] PROGMEM = R"=====(
     }
 
     function schedRaz() {
-      if(!confirm('Clear all scheduled slots?')) return;
+      if(!confirm(T('msg.sched_raz_confirm'))) return;
       schedCells=new Array(336).fill(null);
       renderSchedulerGrid();
     }
@@ -1512,27 +1754,26 @@ const char PAGE_index[] PROGMEM = R"=====(
       fetch('/admin/save/schedulerenabled',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:'enabled='+en});
     }
 
-    async function saveAllScheduler() {
+    function saveAllScheduler() {
       var btn=document.getElementById('schedSaveBtn');
       setSaveButtonState(btn,'saving');
-      try {
-        var hex='';
-        for(var i=0;i<336;i++){
-          var ri=schedCells[i];
-          if(ri===null||ri===undefined){
-            hex+='FFFFFFFFFFFFFFFF';
-          } else {
-            var rule=schedRules[ri];
-            var packed=(rule.colorRandom&0x03)|((rule.animSpeed-1)<<2);
-            hex+=toHex2(rule.mode)+toHex2(rule.anim)+toHex2(packed)
-                +toHex2(rule.animBrightMin)+toHex2(rule.animBrightMax)
-                +toHex2(rule.r)+toHex2(rule.g)+toHex2(rule.b);
-          }
+      var hex='';
+      for(var i=0;i<336;i++){
+        var ri=schedCells[i];
+        if(ri===null||ri===undefined){
+          hex+='FFFFFFFFFFFFFFFF';
+        } else {
+          var rule=schedRules[ri];
+          var packed=(rule.colorRandom&0x03)|((rule.animSpeed-1)<<2);
+          hex+=toHex2(rule.mode)+toHex2(rule.anim)+toHex2(packed)
+              +toHex2(rule.animBrightMin)+toHex2(rule.animBrightMax)
+              +toHex2(rule.r)+toHex2(rule.g)+toHex2(rule.b);
         }
-        await fetch('/admin/save/schedulerbulk',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:'data='+hex});
-        await fetch('/admin/scheduler/apply',{method:'POST'});
-        setSaveButtonState(btn,'success');
-      } catch(e){setSaveButtonState(btn,'error');}
+      }
+      fetch('/admin/save/schedulerbulk',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:'data='+hex})
+        .then(function(){return fetch('/admin/scheduler/apply',{method:'POST'});})
+        .then(function(){setSaveButtonState(btn,'success');})
+        .catch(function(){setSaveButtonState(btn,'error');});
     }
     // ── End Scheduler ──────────────────────────────────────────────────────────
 

--- a/Page_scheduler.h
+++ b/Page_scheduler.h
@@ -1,0 +1,170 @@
+
+// Slot layout in EEPROM (8 bytes per slot):
+//   [0] mode (0xFF = slot disabled)
+//   [1] animation
+//   [2] (colorRandom & 0x03) | ((animSpeed-1) << 2)
+//   [3] animBrightnessMin
+//   [4] animBrightnessMax
+//   [5] R  [6] G  [7] B
+//
+// 336 slots total: 7 days × 48 half-hours (slot = hour*2 + (min>=30?1:0))
+
+inline int schedAddr(byte day, byte slot) {  // slot 0..47
+  return SCHEDULER_EEPROM_BASE + 1 + (int(day) * 48 + slot) * SCHEDULER_SLOT_SIZE;
+}
+
+void send_scheduler_config() {
+  byte en = EEPROM.read(SCHEDULER_EEPROM_BASE);
+  String out = "schedulerEnabled|" + String(en == 1 ? "checked" : "") + "|chk\n";
+  _server.send(200, "text/plain", out);
+}
+
+void send_scheduler_data() {
+  _server.setContentLength(CONTENT_LENGTH_UNKNOWN);
+  _server.send(200, "text/plain", "");
+  char buf[17];
+  for (int day = 0; day < 7; day++) {
+    for (int slot = 0; slot < 48; slot++) {
+      int addr = schedAddr(day, slot);
+      for (int k = 0; k < SCHEDULER_SLOT_SIZE; k++)
+        sprintf(buf + k * 2, "%02X", EEPROM.read(addr + k));
+      buf[16] = 0;
+      _server.sendContent(buf);
+    }
+  }
+  _server.sendContent("");
+}
+
+void save_scheduler_slot() {
+  int day = -1, hour = -1, minute = 0;
+  byte mode = 0xFF, animation = 0, colorRandom = 0, animSpeed = 10;
+  byte animBrightnessMin = 10, animBrightnessMax = 100;
+  byte r = 255, g = 255, b = 255;
+  bool slotEnabled = false;
+
+  for (uint8_t i = 0; i < _server.args(); i++) {
+    String n = _server.argName(i);
+    String v = _server.arg(i);
+    if (n == "day")            day = v.toInt();
+    else if (n == "hour")      hour = v.toInt();
+    else if (n == "minute")    minute = v.toInt();
+    else if (n == "enabled")   slotEnabled = (v == "1");
+    else if (n == "mode")      mode = constrain(v.toInt(), 0, 7);
+    else if (n == "animation") animation = constrain(v.toInt(), 0, 12);
+    else if (n == "colorrandom")   colorRandom = constrain(v.toInt(), 0, 3);
+    else if (n == "animspeed")     animSpeed = constrain(v.toInt(), 1, 20);
+    else if (n == "animbrightmin") animBrightnessMin = constrain(v.toInt(), 0, 100);
+    else if (n == "animbrightmax") animBrightnessMax = constrain(v.toInt(), 0, 100);
+    else if (n == "color") {
+      String cs = v;
+      if (cs.startsWith("#")) cs = cs.substring(1);
+      int32_t l = strtol(cs.c_str(), 0, 16);
+      r = (l >> 16) & 0xFF;
+      g = (l >> 8) & 0xFF;
+      b = l & 0xFF;
+    }
+  }
+
+  if (day < 0 || day > 6 || hour < 0 || hour > 23) {
+    _server.send(400, "text/plain", "ERROR");
+    return;
+  }
+
+  int slot = hour * 2 + (minute >= 30 ? 1 : 0);
+  int addr = schedAddr(day, slot);
+  if (!slotEnabled) {
+    EEPROM.write(addr, 0xFF);
+  } else {
+    EEPROM.write(addr,     mode);
+    EEPROM.write(addr + 1, animation);
+    EEPROM.write(addr + 2, (colorRandom & 0x03) | ((animSpeed - 1) << 2));
+    EEPROM.write(addr + 3, animBrightnessMin);
+    EEPROM.write(addr + 4, animBrightnessMax);
+    EEPROM.write(addr + 5, r);
+    EEPROM.write(addr + 6, g);
+    EEPROM.write(addr + 7, b);
+  }
+  EEPROM.commit();
+  _server.send(200, "text/plain", "OK");
+}
+
+void save_scheduler_enabled() {
+  for (uint8_t i = 0; i < _server.args(); i++) {
+    if (_server.argName(i) == "enabled") {
+      EEPROM.write(SCHEDULER_EEPROM_BASE, _server.arg(i) == "1" ? 1 : 0);
+      EEPROM.commit();
+    }
+  }
+  _server.send(200, "text/plain", "OK");
+}
+
+void save_scheduler_raz() {
+  for (int i = 0; i < 336; i++)
+    EEPROM.write(SCHEDULER_EEPROM_BASE + 1 + i * SCHEDULER_SLOT_SIZE, 0xFF);
+  EEPROM.commit();
+  _server.send(200, "text/plain", "OK");
+}
+
+// Bulk save: body arg "data" = 336*16 hex chars representing all slots
+void save_scheduler_bulk() {
+  String data = _server.arg("data");
+  if (data.length() != 336 * 16) {
+    _server.send(400, "text/plain", "ERROR");
+    return;
+  }
+  char buf[3]; buf[2] = 0;
+  for (int i = 0; i < 336; i++) {
+    int addr = SCHEDULER_EEPROM_BASE + 1 + i * SCHEDULER_SLOT_SIZE;
+    for (int k = 0; k < SCHEDULER_SLOT_SIZE; k++) {
+      buf[0] = data[i * 16 + k * 2];
+      buf[1] = data[i * 16 + k * 2 + 1];
+      EEPROM.write(addr + k, (byte)strtol(buf, 0, 16));
+    }
+  }
+  EEPROM.commit();
+  _server.send(200, "text/plain", "OK");
+}
+
+byte _schedLastSlot = 255;
+byte _schedLastDay  = 255;
+
+void apply_scheduler_now() {
+  _schedLastSlot = 255;
+  _server.send(200, "text/plain", "OK");
+}
+
+// Called from loop() every iteration — runs at most once per half-hour (or immediately after apply_scheduler_now)
+void handleScheduler() {
+  if (EEPROM.read(SCHEDULER_EEPROM_BASE) != 1) return;
+
+  byte currentSlot = _dateTime.hour * 2 + (_dateTime.minute >= 30 ? 1 : 0);
+  // _dateTime.wday: 1=Sunday..7=Saturday → convert to 0=Mon..6=Sun
+  byte currentDay = (_dateTime.wday <= 1) ? 6 : (_dateTime.wday - 2);
+
+  if (currentSlot == _schedLastSlot && currentDay == _schedLastDay) return;
+  _schedLastSlot = currentSlot;
+  _schedLastDay  = currentDay;
+
+  int addr = schedAddr(currentDay, currentSlot);
+  byte mode = EEPROM.read(addr);
+  if (mode == 0xFF || mode > 7) return;
+
+  byte animation      = constrain(EEPROM.read(addr + 1), 0, 12);
+  byte packed         = EEPROM.read(addr + 2);
+  byte colorRandom    = packed & 0x03;
+  byte animSpeed      = constrain(((packed >> 2) & 0x1F) + 1, 1, 20);
+  byte animBrightMin  = constrain(EEPROM.read(addr + 3), 0, 100);
+  byte animBrightMax  = constrain(EEPROM.read(addr + 4), 0, 100);
+  byte cr = EEPROM.read(addr + 5);
+  byte cg = EEPROM.read(addr + 6);
+  byte cb = EEPROM.read(addr + 7);
+
+  _config.animBrightnessMin = animBrightMin;
+  _config.animBrightnessMax = animBrightMax;
+
+  QTLed.setMode(mode);
+  QTLed.setAnimation(animation);
+  QTLed.setColor(cr, cg, cb);
+  QTLed.setColorRandom((RandomColorMode)colorRandom);
+  QTLed.setAnimSpeed(animSpeed);
+}

--- a/Page_style.css.h
+++ b/Page_style.css.h
@@ -1038,5 +1038,38 @@ body {
     height: 10px;
   }
 }
+
+/* Scheduler editor card — compact overrides */
+.sched-editor { padding: 0.65rem !important; }
+.sched-editor .card-title { font-size: 0.95rem; margin-bottom: 0.35rem; }
+.sched-editor .form-group { margin-bottom: 0.3rem; }
+.sched-editor .form-label { font-size: 0.72rem; margin-bottom: 0.1rem; }
+.sched-editor .form-control { padding: 0.22rem 0.45rem; font-size: 0.78rem; }
+.sched-editor .range-group { gap: 0.3rem; }
+.sched-editor .range-input { height: 3px; }
+.sched-editor .range-value { font-size: 0.75rem; min-width: 1.8rem; }
+.sched-editor .sched-rule-item { padding: 0.25rem 0.5rem; margin-bottom: 0.2rem; }
+.sched-editor .sched-rule-num { min-width: 1rem; height: 1rem; font-size: 0.65rem; }
+.sched-editor .sched-rule-led { width: 0.85rem; height: 0.85rem; }
+.sched-editor .btn { padding: 0.28rem 0.6rem; font-size: 0.8rem; }
+
+/* Scheduler grid */
+.sched-grid-wrap { overflow-x: auto; margin-top: 0.5rem; user-select: none; -webkit-user-select: none; }
+.sched-table { border-collapse: collapse; width: 100%; font-size: 0.72rem; }
+.sched-table th { padding: 0.25rem 0.4rem; background: var(--surface); border: 1px solid var(--border); text-align: center; font-weight: 600; }
+.sched-hour { padding: 0.25rem 0.4rem; background: var(--surface); border: 1px solid var(--border); font-weight: 500; white-space: nowrap; font-size: 0.7rem; }
+.sched-cell { border: 1px solid var(--border); min-width: 2.2rem; overflow: hidden; }
+.sched-half { text-align: center; cursor: pointer; height: 0.9rem; line-height: 0.9rem; font-size: 0.6rem; overflow: hidden; transition: opacity 0.15s; }
+.sched-half:hover { opacity: 0.75; outline: 2px solid var(--primary-color); outline-offset: -1px; }
+.sched-half + .sched-half { border-top: 1px solid rgba(128,128,128,0.25); }
+.sched-half.sched-cur { outline: 2px solid #fff; outline-offset: -2px; }
+
+/* Scheduler rules list */
+.sched-rule-item { display:flex; align-items:center; gap:0.5rem; padding:0.4rem 0.6rem; border:1px solid var(--border); border-radius:var(--radius-sm); margin-bottom:0.35rem; cursor:pointer; transition:background 0.15s; }
+.sched-rule-item:hover { background:var(--surface-hover); }
+.sched-rule-active { border-color:var(--primary-color) !important; background:rgba(37,99,235,0.07); }
+.sched-rule-num { min-width:1.2rem; height:1.2rem; border-radius:0.2rem; background:var(--primary-color); color:#fff; font-size:0.7rem; font-weight:700; display:flex; align-items:center; justify-content:center; flex-shrink:0; padding:0 0.2rem; }
+.sched-rule-led { width:1rem; height:1rem; border-radius:2px; border:1px solid var(--border); flex-shrink:0; }
+.sched-rule-del { background:none; border:none; cursor:pointer; color:var(--text-secondary); font-size:0.75rem; padding:0.1rem 0.3rem; border-radius:2px; line-height:1; }
 )=====";
- 
+

--- a/TexTime.ino
+++ b/TexTime.ino
@@ -45,6 +45,7 @@
 #include "Page_mqtt.h"
 #include "Page_script.js.h"
 #include "Page_style.css.h"
+#include "Page_scheduler.h"
 
 
 
@@ -71,7 +72,7 @@ void setup() {
   Serial.println("Booting");
 
   // Config load 
-  EEPROM.begin(1024); // define an EEPROM space of 1024Bytes to store data
+  EEPROM.begin(4096); // 1024 for config + 2688 for scheduler (336 slots × 8 bytes)
   CFG_saved = ReadConfig();
   if (!CFG_saved)
   {
@@ -396,6 +397,12 @@ void setup() {
     _server.send(400, "text/html", "Page not Found");
   });
 
+  _server.on("/admin/schedulerconfig", send_scheduler_config);
+  _server.on("/admin/schedulerdata", send_scheduler_data);
+  _server.on("/admin/save/schedulerbulk", HTTP_POST, save_scheduler_bulk);
+  _server.on("/admin/scheduler/apply", HTTP_POST, apply_scheduler_now);
+  _server.on("/admin/save/schedulerenabled", HTTP_POST, save_scheduler_enabled);
+
   _httpUpdater.setup(&_server);
   _server.begin();
   Serial.println("HTTP server started");
@@ -505,6 +512,7 @@ void loop() {
   mqttPollingPublisher();
 
   // Handle led display
+  handleScheduler();
   QTLed.handle();
 
   // For debug purpose only

--- a/TexTime.ino
+++ b/TexTime.ino
@@ -129,7 +129,7 @@ void setup() {
   //printConfig();
 
   // Configure WiFi
-  WiFiMgr.setAPssid("TexTime-" + String(ESP.getChipId(), HEX));
+  WiFiMgr.setAPssid("TexTime-" + String(ESP.getChipId(), HEX), _config.APPassword);
 
   if (!_config.dhcp)
   {
@@ -217,6 +217,7 @@ void setup() {
   _server.on("/admin/generalanimationsvalues", send_general_animations_values_html);
   _server.on("/admin/generalledconfigvalues", send_general_ledconfig_values_html);
 
+  _server.on("/admin/langvalue", send_lang_value_html);
   _server.on("/admin/led", send_general_led);
   
   // Async save endpoints

--- a/global.h
+++ b/global.h
@@ -44,6 +44,10 @@ struct strConfig {
 } _config;
 
 
+// Scheduler EEPROM layout: 336 slots (7 days × 48 half-hours) × 8 bytes, starting at 1024
+#define SCHEDULER_EEPROM_BASE 1024
+#define SCHEDULER_SLOT_SIZE   8
+
 //  Auxiliary function to handle EEPROM
 
 void EEPROMWritelong(int address, long value){


### PR DESCRIPTION
## Summary

- Adds a JS i18n system to the dashboard: the entire UI switches to French or English instantly when the user changes the **Language** dropdown in General Settings
- ~100 translation keys per language covering all labels, buttons, card titles, status messages, scheduler grid day names, and confirm dialogs
- No server-side cost: a single new endpoint (`/admin/langvalue`) returns the saved language index; all translation logic runs in the browser

> **Note:** this PR builds on top of PR #7 (scheduler). The scheduler section is included here and is also translated.

## Implementation

- **`Page_general.h`** — new `send_lang_value_html()` serving `/admin/langvalue`
- **`Page_index.h`** — `data-i18n` attributes on all static text; `I18N` dictionary (FR/EN); `T()` / `applyI18n()` / `initI18n()` helpers; `updatelang()` calls `applyI18n()` immediately; `loadGeneralSettings()` re-syncs `currentLang` after AJAX reload; all JS-generated strings use `T()`
- **`TexTime.ino`** — registers `/admin/langvalue`; fixes `setAPssid()` (missing `APPassword` argument)

## Test plan

- [ ] Open dashboard with FR device → UI displays in French on load
- [ ] Change Language dropdown to English → UI switches instantly, no reload
- [ ] Save → reload page → language persists
- [ ] All sections (General, Network, NTP, MQTT, Scheduler, Firmware) fully translated
- [ ] Scheduler RAZ confirm dialog and day labels translated
- [ ] Save/Saved/Error button states translated

🤖 Generated with [Claude Code](https://claude.com/claude-code)