### PR TITLE
Feat: scheduler + i18n FR/EN + HSV color picker + animations

### DIFF
--- a/LedStrip.h
+++ b/LedStrip.h
@@ -2113,6 +2113,7 @@ public:
           p.display = true;
           _pPixelContainerOutput->pixelsEdge[e] = p;
         }
+        copyForeground();
       }
         if (--_flashTimer <= 0) {
           _fadeProgress = 0;

--- a/LedStrip.h
+++ b/LedStrip.h
@@ -1378,14 +1378,16 @@ public:
       Pixel head = Pixel(RgbColor(
         (uint8_t)((uint16_t)200 * bMax / 255), bMax,
         (uint8_t)((uint16_t)200 * bMax / 255)));
-      Pixel trail = Pixel(RgbColor(0, bMax, 0));
       for (int r = _matrixColumn[c]; r > _matrixColumn[c] - _matrixColumnSize[c]; r--) {
         int dist = _matrixColumn[c] - r;
         if (dist == 0) {
           _pPixelContainerOutput->pixelsArray.setPixel(head, r, c);
         } else {
-          _pPixelContainerOutput->pixelsArray.setPixel(trail, r, c);
-          if (dist >= 5) trail.color.Darken(35);
+          // Fade proportionally over the full trail length so the tail remains
+          // visible at any animBrightnessMax value (avoids absolute Darken going
+          // to black too fast at low brightness)
+          uint8_t g = (uint8_t)((uint16_t)bMax * (_matrixColumnSize[c] - dist) / _matrixColumnSize[c]);
+          _pPixelContainerOutput->pixelsArray.setPixel(Pixel(RgbColor(0, g, 0)), r, c);
         }
       }
 

--- a/LedStrip.h
+++ b/LedStrip.h
@@ -19,6 +19,7 @@
 //typedef NeoPixelBrightnessBus<NeoGrbFeature, NeoEsp8266AsyncUart1Ws2813Method> MyNeoPixelBrightnessBus;
 typedef NeoPixelBrightnessBus<NeoGrbFeature, NeoEsp8266Uart1Ws2813Method> MyNeoPixelBrightnessBus;
 
+
 class Pixel
 {
 public:
@@ -92,32 +93,67 @@ struct PixelsContainer
   bool hasChanged;
 };
 
+
+
 class LedConfiguration {
 public:
   virtual int ledsByPixelForMatrix() = 0;
   virtual int ledsByPixelForEdges() = 0;
   virtual int ledsNumber() = 0;
   virtual String getName() = 0;
-  virtual const uint16_t *getLedsMatrixId(int row, int col) = 0;
-  virtual const uint16_t *getLedsEdgeId(int n) = 0;
+  virtual const uint8_t *getLedsMatrixId(int row, int col) = 0;
+  virtual const uint8_t *getLedsEdgeId(int n) = 0;
   virtual ~LedConfiguration() {}
 };
 
 class LedConfiguration40x40 : public LedConfiguration {
 private:
-  const uint16_t _matchingPixelsMatrix[NROW][NCOL][1] = {
-    { { 0  }, { 1  }, { 5  }, { 6  }, { 14 }, { 15 }, { 27 }, { 28  }, { 44  }, { 45  }, { 64  } },
-    { { 2  }, { 4  }, { 7  }, { 13 }, { 16 }, { 26 }, { 29 }, { 43  }, { 46  }, { 63  }, { 65  } },
-    { { 3  }, { 8  }, { 12 }, { 17 }, { 25 }, { 30 }, { 42 }, { 47  }, { 62  }, { 66  }, { 81  } },
-    { { 9  }, { 11 }, { 18 }, { 24 }, { 31 }, { 41 }, { 48 }, { 61  }, { 67  }, { 80  }, { 82  } },
-    { { 10 }, { 19 }, { 23 }, { 32 }, { 40 }, { 49 }, { 60 }, { 68  }, { 79  }, { 83  }, { 94  } },
-    { { 20 }, { 22 }, { 33 }, { 39 }, { 50 }, { 59 }, { 69 }, { 78  }, { 84  }, { 93  }, { 95  } },
-    { { 21 }, { 34 }, { 38 }, { 51 }, { 58 }, { 70 }, { 77 }, { 85  }, { 92  }, { 96  }, { 103 } },
-    { { 35 }, { 37 }, { 52 }, { 57 }, { 71 }, { 76 }, { 86 }, { 91  }, { 97  }, { 102 }, { 104 } },
-    { { 36 }, { 53 }, { 56 }, { 72 }, { 75 }, { 87 }, { 90 }, { 98  }, { 101 }, { 105 }, { 108 } },
-    { { 54 }, { 55 }, { 73 }, { 74 }, { 88 }, { 89 }, { 99 }, { 100 }, { 106 }, { 107 }, { 109 } }
+
+// version damien
+  const uint8_t _matchingPixelsMatrix[NROW][NCOL][1] = {
+    { { 55 }, { 54 }, { 36 }, { 35 }, { 21 }, { 20 }, { 10 }, { 9   }, { 3   }, { 2   }, { 0   } },
+    { { 73 }, { 56 }, { 53 }, { 37 }, { 34 }, { 22 }, { 19 }, { 11  }, { 8   }, { 4   }, { 1   } },
+    { { 74 }, { 72 }, { 57 }, { 52 }, { 38 }, { 33 }, { 23 }, { 18  }, { 12  }, { 7   }, { 5   } },
+    { { 88 }, { 75 }, { 71 }, { 58 }, { 51 }, { 39 }, { 32 }, { 24  }, { 17  }, { 13  }, { 6   } },
+    { { 89 }, { 87 }, { 76 }, { 70 }, { 59 }, { 50 }, { 40 }, { 31  }, { 25  }, { 16  }, { 14  } },
+    { { 99 }, { 90 }, { 86 }, { 77 }, { 69 }, { 60 }, { 49 }, { 41  }, { 30  }, { 26  }, { 15  } },
+    { { 100}, { 98 }, { 91 }, { 85 }, { 78 }, { 68 }, { 61 }, { 48  }, { 42  }, { 29  }, { 27  } },
+    { { 106}, { 101}, { 97 }, { 92 }, { 84 }, { 79 }, { 67 }, { 62  }, { 47  }, { 43  }, { 28  } },
+    { { 107}, { 105}, { 102}, { 96 }, { 93 }, { 83 }, { 80 }, { 66  }, { 63  }, { 46  }, { 44  } },
+    { { 109}, { 108}, { 104}, { 103}, { 95 }, { 94 }, { 82 }, { 81 }, { 65  }, { 64  }, { 45  } }
   };
-  const uint16_t _matchingPixelsEdge[NEDGE][1] = { { 112 }, { 111 }, { 110 }, { 113 } };
+  const uint8_t _matchingPixelsEdge[NEDGE][1] = { { 113 }, { 112 }, { 111 }, { 110 } };
+
+// verison originale
+  //const uint8_t _matchingPixelsMatrix[NROW][NCOL][1] = {
+    //{ { 0  }, { 1  }, { 5  }, { 6  }, { 14 }, { 15 }, { 27 }, { 28  }, { 44  }, { 45  }, { 64  } },
+    //{ { 2  }, { 4  }, { 7  }, { 13 }, { 16 }, { 26 }, { 29 }, { 43  }, { 46  }, { 63  }, { 65  } },
+    //{ { 3  }, { 8  }, { 12 }, { 17 }, { 25 }, { 30 }, { 42 }, { 47  }, { 62  }, { 66  }, { 81  } },
+    //{ { 9  }, { 11 }, { 18 }, { 24 }, { 31 }, { 41 }, { 48 }, { 61  }, { 67  }, { 80  }, { 82  } },
+    //{ { 10 }, { 19 }, { 23 }, { 32 }, { 40 }, { 49 }, { 60 }, { 68  }, { 79  }, { 83  }, { 94  } },
+    //{ { 20 }, { 22 }, { 33 }, { 39 }, { 50 }, { 59 }, { 69 }, { 78  }, { 84  }, { 93  }, { 95  } },
+    //{ { 21 }, { 34 }, { 38 }, { 51 }, { 58 }, { 70 }, { 77 }, { 85  }, { 92  }, { 96  }, { 103 } },
+    //{ { 35 }, { 37 }, { 52 }, { 57 }, { 71 }, { 76 }, { 86 }, { 91  }, { 97  }, { 102 }, { 104 } },
+    //{ { 36 }, { 53 }, { 56 }, { 72 }, { 75 }, { 87 }, { 90 }, { 98  }, { 101 }, { 105 }, { 108 } },
+    //{ { 54 }, { 55 }, { 73 }, { 74 }, { 88 }, { 89 }, { 99 }, { 100 }, { 106 }, { 107 }, { 109 } }
+  //};
+  //const uint8_t _matchingPixelsEdge[NEDGE][1] = { { 112 }, { 111 }, { 110 }, { 113 } };
+
+// verison lina et blandine
+ // const uint8_t _matchingPixelsMatrix[NROW][NCOL][1] = {
+   // { { 0  }, { 1  }, { 5  }, { 6  }, { 14 }, { 15 }, { 27 }, { 28  }, { 44  }, { 45  }, { 64  } },
+    //{ { 2  }, { 4  }, { 7  }, { 13 }, { 16 }, { 26 }, { 29 }, { 43  }, { 46  }, { 63  }, { 65  } },
+    //{ { 3  }, { 8  }, { 12 }, { 17 }, { 25 }, { 30 }, { 42 }, { 47  }, { 62  }, { 66  }, { 81  } },
+    //{ { 9  }, { 11 }, { 18 }, { 24 }, { 31 }, { 41 }, { 48 }, { 61  }, { 67  }, { 80  }, { 82  } },
+    //{ { 10 }, { 19 }, { 23 }, { 32 }, { 40 }, { 49 }, { 60 }, { 68  }, { 79  }, { 83  }, { 94  } },
+    //{ { 20 }, { 22 }, { 33 }, { 39 }, { 50 }, { 59 }, { 69 }, { 78  }, { 84  }, { 93  }, { 95  } },
+    //{ { 21 }, { 34 }, { 38 }, { 51 }, { 58 }, { 70 }, { 77 }, { 85  }, { 92  }, { 96  }, { 103 } },
+    //{ { 35 }, { 37 }, { 52 }, { 57 }, { 71 }, { 76 }, { 86 }, { 91  }, { 97  }, { 102 }, { 104 } },
+    //{ { 36 }, { 53 }, { 56 }, { 72 }, { 75 }, { 87 }, { 90 }, { 98  }, { 101 }, { 105 }, { 108 } },
+    //{ { 54 }, { 55 }, { 73 }, { 74 }, { 88 }, { 89 }, { 99 }, { 100 }, { 106 }, { 107 }, { 109 } }
+  //};
+  //const uint8_t _matchingPixelsEdge[NEDGE][1] = { { 112 }, { 113 }, { 110 }, { 111 } };
+  
 
 public:
   virtual String getName()
@@ -140,7 +176,7 @@ public:
     return (NROW * NCOL) + NEDGE;
   }
 
-  const uint16_t *getLedsMatrixId(int row, int col)
+  const uint8_t *getLedsMatrixId(int row, int col)
   {
     if (row < 0) return NULL;
     if (col < 0) return NULL;
@@ -150,7 +186,7 @@ public:
     return _matchingPixelsMatrix[row][col];
   }
 
-  const uint16_t *getLedsEdgeId(int n)
+  const uint8_t *getLedsEdgeId(int n)
   {
     if (n < 0) return NULL;
     if (n > NEDGE - 1) return NULL;
@@ -161,7 +197,7 @@ public:
 
 class LedConfiguration100x100_1 : public LedConfiguration {
 private:
-  const uint16_t _matchingPixelsMatrix[NROW][NCOL][1] = {
+  const uint8_t _matchingPixelsMatrix[NROW][NCOL][1] = {
     { { 21  }, { 19  }, { 17  }, { 15  }, { 13  }, { 11  }, { 9   }, { 7   }, { 5   }, { 3   }, { 1   } },
     { { 24  }, { 26  }, { 28  }, { 30  }, { 32  }, { 34  }, { 36  }, { 38  }, { 40  }, { 42  }, { 44  } },
     { { 67  }, { 65  }, { 63  }, { 61  }, { 59  }, { 57  }, { 55  }, { 53  }, { 51  }, { 49  }, { 47  } },
@@ -173,7 +209,7 @@ private:
     { { 205 }, { 203 }, { 201 }, { 199 }, { 197 }, { 195 }, { 193 }, { 191 }, { 189 }, { 187 }, { 185 } },
     { { 208 }, { 210 }, { 212 }, { 214 }, { 216 }, { 218 }, { 220 }, { 222 }, { 224 }, { 226 }, { 228 } }
   };
-  const uint16_t _matchingPixelsEdge[NEDGE][1] = { { 232 }, { 231 }, { 230 }, { 233 } };
+  const uint8_t _matchingPixelsEdge[NEDGE][1] = { { 232 }, { 231 }, { 230 }, { 233 } };
 
 public:
   virtual String getName()
@@ -196,7 +232,7 @@ public:
     return (NROW * 23) + NEDGE;
   }
 
-  const uint16_t *getLedsMatrixId(int row, int col)
+  const uint8_t *getLedsMatrixId(int row, int col)
   {
     if (row < 0) return NULL;
     if (col < 0) return NULL;
@@ -206,7 +242,7 @@ public:
     return _matchingPixelsMatrix[row][col];
   }
 
-  const uint16_t *getLedsEdgeId(int n)
+  const uint8_t *getLedsEdgeId(int n)
   {
     if (n < 0) return NULL;
     if (n > NEDGE - 1) return NULL;
@@ -217,7 +253,7 @@ public:
 
 class LedConfiguration100x100_2 : public LedConfiguration {
 private:
-  const uint16_t _matchingPixelsMatrix[NROW][NCOL][2] = {
+  const uint8_t _matchingPixelsMatrix[NROW][NCOL][2] = {
     { { 21 , 22  }, { 19 , 20  }, { 17 , 18  }, { 15 , 16  }, { 13 , 14  }, { 11 , 12  }, { 9  , 10  }, { 7  , 8   }, { 5  , 6   }, { 3  , 4   }, { 1  , 2   } },
     { { 25 , 26  }, { 27 , 28  }, { 29 , 30  }, { 31 , 32  }, { 33 , 34  }, { 35 , 36  }, { 37 , 38  }, { 39 , 40  }, { 41 , 42  }, { 43 , 44  }, { 45 , 46  } },
     { { 69 , 70  }, { 67 , 68  }, { 65 , 66  }, { 63 , 64  }, { 61 , 62  }, { 59 , 60  }, { 57 , 58  }, { 55 , 56  }, { 53 , 54  }, { 51 , 52  }, { 49 , 50  } },
@@ -229,7 +265,7 @@ private:
     { { 213, 214 }, { 211, 212 }, { 209, 210 }, { 207, 208 }, { 205, 206 }, { 203, 204 }, { 201, 202 }, { 199, 200 }, { 197, 198 }, { 195, 196 }, { 193, 194 } },
     { { 217, 218 }, { 219, 220 }, { 221, 222 }, { 223, 224 }, { 225, 226 }, { 227, 228 }, { 229, 230 }, { 231, 232 }, { 233, 234 }, { 235, 236 }, { 237, 238 } }
   };
-  const uint16_t _matchingPixelsEdge[NEDGE][1] = { { 242 }, { 241 }, { 240 }, { 243 } };
+  const uint8_t _matchingPixelsEdge[NEDGE][1] = { { 242 }, { 241 }, { 240 }, { 243 } };
 
 public:
   virtual String getName()
@@ -252,7 +288,7 @@ public:
     return (NROW * 24) + NEDGE;
   }
 
-  const uint16_t *getLedsMatrixId(int row, int col)
+  const uint8_t *getLedsMatrixId(int row, int col)
   {
     if (row < 0) return NULL;
     if (col < 0) return NULL;
@@ -262,7 +298,7 @@ public:
     return _matchingPixelsMatrix[row][col];
   }
 
-  const uint16_t *getLedsEdgeId(int n)
+  const uint8_t *getLedsEdgeId(int n)
   {
     if (n < 0) return NULL;
     if (n > NEDGE - 1) return NULL;
@@ -271,68 +307,14 @@ public:
   }
 };
 
-class LedConfiguration100x100_3 : public LedConfiguration {
-private:
-  const uint16_t _matchingPixelsMatrix[NROW][NCOL][2] = {
-    { { 21 , 22  }, { 19 , 20  }, { 17 , 18  }, { 15 , 16  }, { 13 , 14  }, { 11 , 12  }, { 9  , 10  }, { 7  , 8   }, { 5  , 6   }, { 3  , 4   }, { 1  , 2   } },
-    { { 27 , 28  }, { 29 , 30  }, { 31 , 32  }, { 33 , 34  }, { 35 , 36  }, { 37 , 38  }, { 39 , 40  }, { 41 , 42  }, { 43 , 44  }, { 45 , 46  }, { 47 , 48  } },
-    { { 73 , 74  }, { 71 , 72  }, { 69 , 70  }, { 67 , 68  }, { 65 , 66  }, { 63 , 64  }, { 61 , 62  }, { 59 , 60  }, { 57 , 58  }, { 55 , 56  }, { 53 , 54  } },
-    { { 79 , 80  }, { 81 , 82  }, { 83 , 84  }, { 85 , 86  }, { 87 , 88  }, { 89 , 90  }, { 91 , 92  }, { 93 , 94  }, { 95 , 96  }, { 97 , 98  }, { 99 , 100 } },
-    { { 125, 126 }, { 123, 124 }, { 121, 122 }, { 119, 120 }, { 117, 118 }, { 115, 116 }, { 113, 114 }, { 111, 112 }, { 109, 110 }, { 107, 108 }, { 105, 106 } },
-    { { 131, 132 }, { 133, 134 }, { 135, 136 }, { 137, 138 }, { 139, 140 }, { 141, 142 }, { 143, 144 }, { 145, 146 }, { 147, 148 }, { 149, 150 }, { 151, 152 } },
-    { { 177, 178 }, { 175, 176 }, { 173, 174 }, { 171, 172 }, { 169, 170 }, { 167, 168 }, { 165, 166 }, { 163, 164 }, { 161, 162 }, { 159, 160 }, { 157, 158 } },
-    { { 183, 184 }, { 185, 186 }, { 187, 188 }, { 189, 190 }, { 191, 192 }, { 193, 194 }, { 195, 196 }, { 197, 198 }, { 199, 200 }, { 201, 202 }, { 203, 204 } },
-    { { 229, 230 }, { 227, 228 }, { 225, 226 }, { 223, 224 }, { 221, 222 }, { 219, 220 }, { 217, 218 }, { 215, 216 }, { 213, 214 }, { 211, 212 }, { 209, 210 } },
-    { { 235, 236 }, { 237, 238 }, { 239, 240 }, { 241, 242 }, { 243, 244 }, { 245, 246 }, { 247, 248 }, { 249, 250 }, { 251, 252 }, { 253, 254 }, { 255, 256 } },
-  };
-  const uint16_t _matchingPixelsEdge[NEDGE][1] = { { 260 }, { 259 }, { 258 }, { 261 } };
 
-public:
-  virtual String getName()
-  {
-    return "100x100@3";
-  }
-
-  int ledsByPixelForMatrix()
-  {
-    return 2;
-  }
-
-  int ledsByPixelForEdges()
-  {
-    return 1;
-  }
-
-  int ledsNumber()
-  {
-    return 262;
-  }
-
-  const uint16_t *getLedsMatrixId(int row, int col)
-  {
-    if (row < 0) return NULL;
-    if (col < 0) return NULL;
-    if (row > NROW - 1) return NULL;
-    if (col > NCOL - 1) return NULL;
-
-    return _matchingPixelsMatrix[row][col];
-  }
-
-  const uint16_t *getLedsEdgeId(int n)
-  {
-    if (n < 0) return NULL;
-    if (n > NEDGE - 1) return NULL;
-
-    return _matchingPixelsEdge[n];
-  }
-};
 
 //  0         x
 // 0+----------
 //  |
 //  |
 //  |
-// y|
+// y|  
 //
 void copyCharToMatrix(const uint8_t src[FONTROW][FONTCOL], PixelsArray &dst, int posx, int posy, const RgbColor &color)
 {
@@ -363,6 +345,7 @@ void copyNumberToMatrix(int n, PixelsArray &dst, const RgbColor &color)
   ::copyCharToMatrix(_font_number[abs(n % 10)], dst, x, 0 + 6, color); // Display "Second number"
 }
 
+
 enum RandomColorMode
 {
   ColorRandomNo = 0,
@@ -370,6 +353,7 @@ enum RandomColorMode
   ColorRandomLetter,
   ColorRandomWord
 };
+
 
 class LedStripMode
 {
@@ -391,7 +375,7 @@ protected:
     // Clear pixels
     setPixelsColor(pVOID);
   }
-
+  
 public:
   LedStripMode(String name, PixelsContainer *pPixelContainer)
     : _name(name)
@@ -420,6 +404,7 @@ public:
   {
     _colorRandomMode = c;
   }
+
 
   virtual void begin() = 0;
   virtual void handle() = 0;
@@ -450,6 +435,7 @@ public:
   {
     return true;
   }
+
 };
 
 #define LedStripModeTimeName "Time"
@@ -567,6 +553,7 @@ public:
   }
 };
 
+
 class LedStripModeSeconds : public LedStripMode
 {
 private:
@@ -642,6 +629,7 @@ public:
     return true;
   }
 };
+
 
 class LedStripModeTemperature : public LedStripMode
 {
@@ -793,6 +781,7 @@ public:
   }
 };
 
+
 class LedStripModeTestStrip : public LedStripMode
 {
 private:
@@ -842,6 +831,7 @@ public:
   }
 };
 
+
 class MyLedStrip
 {
 protected:
@@ -868,7 +858,7 @@ protected:
     for (int r = 0; r < NROW; r++) {
       for (int c = 0; c < NCOL; c++) {
         Pixel p = pPixel->pixelsArray.getPixel(r, c);
-        const uint16_t *i = _ledConfiguration[_ledConfigurationIndex]->getLedsMatrixId(r, c);
+        const uint8_t *i = _ledConfiguration[_ledConfigurationIndex]->getLedsMatrixId(r, c);
 
         if (!p.display) continue;
 
@@ -880,7 +870,7 @@ protected:
     // Fill leds strip with edge pixels
     for (int e = 0; e < NEDGE; e++) {
       Pixel p = pPixel->pixelsEdge[e];
-      const uint16_t *i = _ledConfiguration[_ledConfigurationIndex]->getLedsEdgeId(e);
+      const uint8_t *i = _ledConfiguration[_ledConfigurationIndex]->getLedsEdgeId(e);
 
       if (!p.display) continue;
 
@@ -910,7 +900,8 @@ protected:
     {
       int sd = _config.brightnessAutoMinDay;      // minimum brightness during the day
       int sn = _config.brightnessAutoMinNight;    // minimum brightness during the night
-      int sm = 255;                               // maximum brightness
+      //int sm = 255;                               // maximum brightness
+      int sm = _config.brightnessMax;         // maximum brightness auto
       int lmin = 0;                               // minimum lux sensitivity allowed
       int lmax = _config.luxSensitivity * 10;     // maximum lux sensitivity allowed
 
@@ -951,10 +942,10 @@ public:
     , _automaticBrightness(false)
     , _modeIndex(0)
   {
+
     _ledConfiguration.push_back(new LedConfiguration40x40());
     _ledConfiguration.push_back(new LedConfiguration100x100_1());
     _ledConfiguration.push_back(new LedConfiguration100x100_2());
-    _ledConfiguration.push_back(new LedConfiguration100x100_3());
 
     _modeList.push_back(new LedStripModeNothing(&_pixels));
     _modeList.push_back(new LedStripModeTime(&_pixels));
@@ -999,9 +990,9 @@ public:
     end();
 
     if (!_pStrip)
-    {
+    { 
       _ledConfigurationIndex = _config.ledConfig;
-
+      
       // Cannot use DMA because DMA GPIO is already used by serial/USB bridge :(
       _pStrip = new MyNeoPixelBrightnessBus(_ledConfiguration[_ledConfigurationIndex]->ledsNumber(), D4);
       _pStrip->Begin();
@@ -1128,6 +1119,9 @@ public:
   }
 };
 
+
+
+
 class LedStripAnimation
 {
 protected:
@@ -1245,7 +1239,7 @@ public:
 
   void begin()
   {
-    _frame.init(50);
+    _frame.init(50.0 * _config.animSpeed / 5.0);
 
     initPixelsList();
     clearPixelsColor();
@@ -1283,10 +1277,11 @@ private:
 
   RgbColor generateFireColor()
   {
-    RgbColor c = RgbColor(58, 58, 6);
-    c.Darken(random(15));
-    c.R += random(15);
-    return c;
+    uint8_t bMax = (uint8_t)((uint16_t)_config.animBrightnessMax * 255 / 100);
+    return RgbColor(
+      (uint8_t)((uint16_t)(200 + random(55)) * bMax / 255),
+      (uint8_t)((uint16_t)(30 + random(120)) * bMax / 255),
+      (uint8_t)((uint16_t)random(20) * bMax / 255));
   }
 
 public:
@@ -1297,7 +1292,7 @@ public:
 
   void begin()
   {
-    _frame.init(8);
+    _frame.init(8.0 * _config.animSpeed / 5.0);
   }
 
   void handle()
@@ -1336,21 +1331,22 @@ class LedStripAnimationMatrix : public LedStripAnimation
 private:
   Frame _frame;
   int _matrixColumn[NCOL];
-  int _matrixColumnSize;
+  int _matrixColumnSize[NCOL];
 
 public:
   LedStripAnimationMatrix(PixelsContainer *pPixelContainerInput, PixelsContainer *pPixelContainerOutput)
     : LedStripAnimation("Matrix", pPixelContainerInput, pPixelContainerOutput)
-    , _matrixColumnSize(9)
   {
   }
 
   void begin()
   {
-    _frame.init(8);
+    _frame.init(8.0 * _config.animSpeed / 10.0);
 
-    for (int i = 0; i < NCOL; i++)
+    for (int i = 0; i < NCOL; i++) {
       _matrixColumn[i] = -1;
+      _matrixColumnSize[i] = 0;
+    }
   }
 
   void handle()
@@ -1365,26 +1361,37 @@ public:
     // Create a new column if possible (= -1)
     for (int c = 0; c < NCOL; c++) {
       if (_matrixColumn[c] == -1) {
-        if (random(30) == 0) {
+        if (random(10) == 0) {
           _matrixColumn[c] = 0;
+          _matrixColumnSize[c] = 8 + random(12); // 8 à 19 pixels
         }
       }
     }
+
+    uint8_t bMax = (uint8_t)((uint16_t)_config.animBrightnessMax * 255 / 100);
 
     // Update display columns
     for (int c = 0; c < NCOL; c++) {
       if (_matrixColumn[c] == -1)
         continue;
 
-      Pixel green = pGREEN;
-      for (int r = _matrixColumn[c]; r > _matrixColumn[c] - _matrixColumnSize; r--) {
-        _pPixelContainerOutput->pixelsArray.setPixel(green, r, c);
-        green.color.Darken(30);
+      Pixel head = Pixel(RgbColor(
+        (uint8_t)((uint16_t)200 * bMax / 255), bMax,
+        (uint8_t)((uint16_t)200 * bMax / 255)));
+      Pixel trail = Pixel(RgbColor(0, bMax, 0));
+      for (int r = _matrixColumn[c]; r > _matrixColumn[c] - _matrixColumnSize[c]; r--) {
+        int dist = _matrixColumn[c] - r;
+        if (dist == 0) {
+          _pPixelContainerOutput->pixelsArray.setPixel(head, r, c);
+        } else {
+          _pPixelContainerOutput->pixelsArray.setPixel(trail, r, c);
+          if (dist >= 5) trail.color.Darken(35);
+        }
       }
 
       _matrixColumn[c]++;
 
-      if (_matrixColumn[c] > NROW + _matrixColumnSize)
+      if (_matrixColumn[c] > NROW + _matrixColumnSize[c])
         _matrixColumn[c] = -1;
     }
 
@@ -1423,7 +1430,7 @@ public:
 
   void begin()
   {
-    _frame.init(10);
+    _frame.init(10.0 * _config.animSpeed / 5.0);
   }
 
   void handle()
@@ -1433,7 +1440,7 @@ public:
 
     clearPixelsColor();
 
-    _rainbowIndex += 0.001;
+    _rainbowIndex += 0.004;
 
     if (_rainbowIndex > 1.0)
       _rainbowIndex = 0.0;
@@ -1441,7 +1448,8 @@ public:
     // Copy foreground matrix pixels
     for (int c = 0; c < NCOL; c++) {
       for (int r = 0; r < NROW; r++) {
-        double hsl = ((double)((r * NCOL) + c) / (double)(NROW * NCOL)) * (60.0 / 360.0);
+
+        double hsl = (double)((r * NCOL) + c) / (double)(NROW * NCOL);
         hsl += _rainbowIndex;
         if (hsl > 1.0) hsl -= 1.0;
 
@@ -1486,7 +1494,7 @@ public:
 
   void begin()
   {
-    _frame.init(4);
+    _frame.init(4.0 * _config.animSpeed / 5.0);
 
     for (int i = 0; i < NCOL; i++)
       _matrixColumn[i] = -1;
@@ -1515,7 +1523,8 @@ public:
       if (_matrixColumn[c] == -1)
         continue;
 
-      Pixel green = pWHITE;
+      uint8_t bMax = (uint8_t)((uint16_t)_config.animBrightnessMax * 255 / 100);
+      Pixel green = Pixel(RgbColor(bMax, bMax, bMax));
       for (int r = _matrixColumn[c]; r > _matrixColumn[c] - _matrixColumnSize; r--) {
         _pPixelContainerOutput->pixelsArray.setPixel(green, r, c);
         green.color.Darken(128);
@@ -1560,7 +1569,7 @@ public:
 
   void begin()
   {
-    _frame.init(5);
+    _frame.init(5.0 * _config.animSpeed / 5.0);
   }
 
   Pixel generateFire()
@@ -1582,9 +1591,13 @@ public:
 
     if (_dateTime.second / 10 % 2)
     {
-      Pixel white = Pixel(RgbColor(255, 255, 255));
-      Pixel red = Pixel(RgbColor(255, 0, 0));
-      Pixel brown = Pixel(RgbColor(125, 57, 0));
+      uint8_t bMax = (uint8_t)((uint16_t)_config.animBrightnessMax * 255 / 100);
+      Pixel white = Pixel(RgbColor(bMax, bMax, bMax));
+      Pixel red = Pixel(RgbColor(bMax, 0, 0));
+      Pixel brown = Pixel(RgbColor(
+        (uint8_t)((uint16_t)125 * bMax / 255),
+        (uint8_t)((uint16_t)57 * bMax / 255),
+        0));
 
       _pPixelContainerOutput->pixelsArray.setPixel(generateFire(), 2, 3);
       _pPixelContainerOutput->pixelsArray.setPixel(generateFire(), 2, 5);
@@ -1667,6 +1680,7 @@ public:
   }
 };
 
+
 class LedStripAnimationLove : public LedStripAnimation
 {
 private:
@@ -1680,7 +1694,7 @@ public:
 
   void begin()
   {
-    _frame.init(5);
+    _frame.init(5.0 * _config.animSpeed / 5.0);
   }
 
   void handle()
@@ -1693,8 +1707,12 @@ public:
     if (_dateTime.second / 10 % 2)
     {
       //Pixel white = Pixel(RgbColor(255, 255, 255));
-      Pixel red = Pixel(RgbColor(255, 0, 0));
-      Pixel pink = Pixel(RgbColor(0x69, 0x28, 0xDE));
+      uint8_t bMax = (uint8_t)((uint16_t)_config.animBrightnessMax * 255 / 100);
+      Pixel red = Pixel(RgbColor(bMax, 0, 0));
+      Pixel pink = Pixel(RgbColor(
+        (uint8_t)((uint16_t)0x69 * bMax / 255),
+        (uint8_t)((uint16_t)0x28 * bMax / 255),
+        (uint8_t)((uint16_t)0xDE * bMax / 255)));
 
       _pPixelContainerOutput->pixelsArray.setPixel(pink, 1, 2);
       _pPixelContainerOutput->pixelsArray.setPixel(pink, 1, 3);
@@ -1776,53 +1794,81 @@ public:
   }
 };
 
-class LedStripAnimationRipple : public LedStripAnimation
+class LedStripAnimationPulse : public LedStripAnimation
 {
 private:
-  struct Ripple {
-    int originR, originC;
-    int radius;
-    RgbColor baseColor;
-    bool active;
-  };
-
-  static const int MAX_RIPPLES = 2;
-  Ripple _ripples[MAX_RIPPLES];
   Frame _frame;
-
-  bool isInBounds(int r, int c)
-  {
-    return r >= 0 && r < NROW &&c >= 0 && c < NCOL;
-  }
-
-  void createNewRipple(int index)
-  {
-    _ripples[index].originR = random(NROW);
-    _ripples[index].originC = random(NCOL);
-    _ripples[index].radius = 0;
-    _ripples[index].baseColor = RgbColor(random(128, 255), random(64), random(255));
-    _ripples[index].active = true;
-  }
-
-  double euclideanDistance(int r1, int c1, int r2, int c2)
-  {
-    return sqrt((r1 - r2) * (r1 - r2) + (c1 - c2) * (c1 - c2));
-  }
+  uint16_t _phase;
 
 public:
-  LedStripAnimationRipple(PixelsContainer *pPixelContainerInput, PixelsContainer *pPixelContainerOutput)
-    : LedStripAnimation("Ripple", pPixelContainerInput, pPixelContainerOutput)
+  LedStripAnimationPulse(PixelsContainer *pPixelContainerInput, PixelsContainer *pPixelContainerOutput)
+    : LedStripAnimation("Pulse", pPixelContainerInput, pPixelContainerOutput)
+    , _phase(0)
   {
   }
 
   void begin()
   {
-    _frame.init(8);
-    for (int i = 0; i < MAX_RIPPLES; i++)
-      _ripples[i].active = false;
+    _frame.init(20.0 * _config.animSpeed / 5.0);
+    _phase = 0;
+  }
 
-    // Start the first wave
-    createNewRipple(0);
+  void handle()
+  {
+    if (!_frame.next())
+      return;
+
+    _phase = (_phase + 3) & 511;
+    uint8_t v = (_phase < 256) ? (uint8_t)_phase : (uint8_t)(511 - _phase);
+    uint8_t bMin = (uint8_t)((uint16_t)_config.animBrightnessMin * 255 / 100);
+    uint8_t bMax = (uint8_t)((uint16_t)_config.animBrightnessMax * 255 / 100);
+    uint8_t b = (bMax > bMin) ? (bMin + (uint8_t)((uint16_t)v * (bMax - bMin) / 255)) : bMin;
+
+    clearPixelsColor();
+
+    for (int c = 0; c < NCOL; c++) {
+      for (int r = 0; r < NROW; r++) {
+        Pixel pf = _pPixelContainerInput->pixelsArray.getPixel(r, c);
+        if (pf.display) {
+          pf.color = RgbColor(
+            (uint8_t)((uint16_t)pf.color.R * b / 255),
+            (uint8_t)((uint16_t)pf.color.G * b / 255),
+            (uint8_t)((uint16_t)pf.color.B * b / 255));
+          _pPixelContainerOutput->pixelsArray.setPixel(pf, r, c);
+        }
+      }
+    }
+    for (int e = 0; e < NEDGE; e++) {
+      Pixel pf = _pPixelContainerInput->pixelsEdge[e];
+      if (pf.display) {
+        pf.color = RgbColor(
+          (uint8_t)((uint16_t)pf.color.R * b / 255),
+          (uint8_t)((uint16_t)pf.color.G * b / 255),
+          (uint8_t)((uint16_t)pf.color.B * b / 255));
+        _pPixelContainerOutput->pixelsEdge[e] = pf;
+      }
+    }
+    _pPixelContainerOutput->hasChanged = true;
+  }
+};
+
+class LedStripAnimationSparkle : public LedStripAnimation
+{
+private:
+  Frame _frame;
+  uint8_t _sparks[NROW][NCOL];
+
+public:
+  LedStripAnimationSparkle(PixelsContainer *pPixelContainerInput, PixelsContainer *pPixelContainerOutput)
+    : LedStripAnimation("Sparkle", pPixelContainerInput, pPixelContainerOutput)
+  {
+    memset(_sparks, 0, sizeof(_sparks));
+  }
+
+  void begin()
+  {
+    _frame.init(15.0 * _config.animSpeed / 10.0);
+    memset(_sparks, 0, sizeof(_sparks));
   }
 
   void handle()
@@ -1832,48 +1878,147 @@ public:
 
     clearPixelsColor();
 
-    for (int r = 0; r < NROW; r++) {
-      for (int c = 0; c < NCOL; c++) {
-        Pixel p;
-        p.display = false;
-
-        for (int i = 0; i < MAX_RIPPLES; i++) {
-          if (!_ripples[i].active)
-            continue;
-
-          double dist = euclideanDistance(r, c, _ripples[i].originR, _ripples[i].originC);
-
-          if (abs(dist - _ripples[i].radius) < 0.5) {
-            RgbColor color = _ripples[i].baseColor;
-            int darkenAmount = (int)(dist * 10);
-            color.Darken(darkenAmount);
-
-            p.color = color;
+    for (int c = 0; c < NCOL; c++) {
+      for (int r = 0; r < NROW; r++) {
+        Pixel pf = _pPixelContainerInput->pixelsArray.getPixel(r, c);
+        if (pf.display) {
+          _sparks[r][c] = 0;
+          _pPixelContainerOutput->pixelsArray.setPixel(pf, r, c);
+        } else {
+          if (_sparks[r][c] > 40)
+            _sparks[r][c] -= 40;
+          else {
+            _sparks[r][c] = 0;
+            if (random(NROW * NCOL * 2) == 0)
+              _sparks[r][c] = 220;
+          }
+          if (_sparks[r][c] > 0) {
+            Pixel p;
+            p.color = RgbColor(
+              (uint8_t)((uint16_t)_sparks[r][c] * _config.animBrightnessMax / 100),
+              (uint8_t)((uint16_t)_sparks[r][c] * _config.animBrightnessMax / 100),
+              (uint8_t)((uint16_t)_sparks[r][c] * _config.animBrightnessMax / 100));
             p.display = true;
-            break;
+            _pPixelContainerOutput->pixelsArray.setPixel(p, r, c);
           }
         }
-
-        if (p.display)
-          _pPixelContainerOutput->pixelsArray.setPixel(p, r, c);
       }
     }
+    for (int e = 0; e < NEDGE; e++) {
+      Pixel pf = _pPixelContainerInput->pixelsEdge[e];
+      if (pf.display)
+        _pPixelContainerOutput->pixelsEdge[e] = pf;
+    }
+    _pPixelContainerOutput->hasChanged = true;
+  }
+};
 
-    for (int i = 0; i < MAX_RIPPLES; i++) {
-      if (_ripples[i].active) {
-        _ripples[i].radius++;
+class LedStripAnimationWave : public LedStripAnimation
+{
+private:
+  Frame _frame;
+  uint8_t _phase;
 
-        if (_ripples[i].radius > (NROW + NCOL) / 2) {
-          _ripples[i].active = false;
+public:
+  LedStripAnimationWave(PixelsContainer *pPixelContainerInput, PixelsContainer *pPixelContainerOutput)
+    : LedStripAnimation("Wave", pPixelContainerInput, pPixelContainerOutput)
+    , _phase(0)
+  {
+  }
+
+  void begin()
+  {
+    _frame.init(15.0 * _config.animSpeed / 5.0);
+    _phase = 0;
+  }
+
+  void handle()
+  {
+    if (!_frame.next())
+      return;
+
+    _phase += 2;
+
+    uint8_t bMin = (uint8_t)((uint16_t)_config.animBrightnessMin * 255 / 100);
+    uint8_t bMax = (uint8_t)((uint16_t)_config.animBrightnessMax * 255 / 100);
+    uint8_t bRange = (bMax > bMin) ? (bMax - bMin) : 0;
+
+    clearPixelsColor();
+
+    for (int c = 0; c < NCOL; c++) {
+      uint8_t colPhase = _phase + (uint8_t)(c * 255 / (NCOL - 1));
+      uint8_t tri = (colPhase < 128) ? (uint8_t)(colPhase << 1) : (uint8_t)((255 - colPhase) << 1);
+      uint8_t b = bMin + (uint8_t)((uint16_t)tri * bRange / 255);
+
+      for (int r = 0; r < NROW; r++) {
+        Pixel pf = _pPixelContainerInput->pixelsArray.getPixel(r, c);
+        if (pf.display) {
+          pf.color = RgbColor(
+            (uint8_t)((uint16_t)pf.color.R * b / 255),
+            (uint8_t)((uint16_t)pf.color.G * b / 255),
+            (uint8_t)((uint16_t)pf.color.B * b / 255));
+          _pPixelContainerOutput->pixelsArray.setPixel(pf, r, c);
         }
       }
-
-      if (!_ripples[i].active && random(100) < 10) {
-        createNewRipple(i);
+    }
+    for (int e = 0; e < NEDGE; e++) {
+      Pixel pf = _pPixelContainerInput->pixelsEdge[e];
+      if (pf.display) {
+        uint8_t ePhase = _phase + (uint8_t)(e * 64);
+        uint8_t tri = (ePhase < 128) ? (uint8_t)(ePhase << 1) : (uint8_t)((255 - ePhase) << 1);
+        uint8_t b = bMin + (uint8_t)((uint16_t)tri * bRange / 255);
+        pf.color = RgbColor(
+          (uint8_t)((uint16_t)pf.color.R * b / 255),
+          (uint8_t)((uint16_t)pf.color.G * b / 255),
+          (uint8_t)((uint16_t)pf.color.B * b / 255));
+        _pPixelContainerOutput->pixelsEdge[e] = pf;
       }
     }
+    _pPixelContainerOutput->hasChanged = true;
+  }
+};
 
-    // Copy foreground matrix pixels
+class LedStripAnimationLightning : public LedStripAnimation
+{
+protected:
+  Frame _frame;
+
+  enum Phase { PAUSE, BUILD, FLASH, FADE };
+  Phase _phase;
+
+  bool _boltGrid[NROW][NCOL];
+  int  _buildRow;
+  int  _flashTimer;
+  int  _pauseTimer;
+  int  _fadeProgress;
+
+  void generateBolt()
+  {
+    memset(_boltGrid, 0, sizeof(_boltGrid));
+    int8_t c = random(NCOL);
+    for (int r = 0; r < NROW; r++) {
+      _boltGrid[r][c] = true;
+      c = (int8_t)constrain(c + (int8_t)(random(3) - 1), 0, NCOL - 1);
+    }
+    int numBranches = random(3);
+    for (int b = 0; b < numBranches; b++) {
+      int startRow = 1 + random(NROW / 2);
+      int8_t bc = -1;
+      for (int col = 0; col < NCOL; col++) {
+        if (_boltGrid[startRow][col]) { bc = col; break; }
+      }
+      if (bc < 0) continue;
+      bc = (int8_t)constrain(bc + (int8_t)(random(3) - 1), 0, NCOL - 1);
+      for (int r = startRow + 1; r < NROW; r++) {
+        _boltGrid[r][bc] = true;
+        bc = (int8_t)constrain(bc + (int8_t)(random(3) - 1), 0, NCOL - 1);
+        if (random(3) == 0) break;
+      }
+    }
+  }
+
+  void copyForeground()
+  {
     for (int c = 0; c < NCOL; c++) {
       for (int r = 0; r < NROW; r++) {
         Pixel pf = _pPixelContainerInput->pixelsArray.getPixel(r, c);
@@ -1881,160 +2026,34 @@ public:
           _pPixelContainerOutput->pixelsArray.setPixel(pf, r, c);
       }
     }
-
-    // Copy foreground edge pixels
     for (int e = 0; e < NEDGE; e++) {
       Pixel pf = _pPixelContainerInput->pixelsEdge[e];
       if (pf.display)
         _pPixelContainerOutput->pixelsEdge[e] = pf;
     }
-
-    _pPixelContainerOutput->hasChanged = true;
-  }
-};
-
-class LedStripAnimationMinuteFall : public LedStripAnimation
-{
-private:
-  struct FallingPixel : PixelPos {
-    int ce;
-    int cc;
-    int cr;
-  };
-
-  Frame _frame;
-  int _lastMinute;
-  bool _animationInProgress;
-  int _animationPhase; // 0: falling old pixels, 1: rising new pixels
-
-  cl_Lst<PixelPos> _oldPixelPositions;
-  cl_Lst<FallingPixel> _fallingPixels;
-
-  void getPixelsList()
-  {
-    _oldPixelPositions.clear();
-
-    // Retrieve currently displayed pixels (old minute)
-    for (int c = 0; c < NCOL; c++) {
-      for (int r = 0; r < NROW; r++) {
-        Pixel p = _pPixelContainerInput->pixelsArray.getPixel(r, c);
-        if (p.display) {
-          PixelPos pp;
-          pp.e = -1;
-          pp.c = c;
-          pp.r = r;
-          pp.p = p;
-          _oldPixelPositions.push_back(pp);
-        }
-      }
-    }
-
-    // Retrieve edge pixels (old minute)
-    for (int e = 0; e < NEDGE; e++) {
-      Pixel p = _pPixelContainerInput->pixelsEdge[e];
-      if (p.display) {
-        PixelPos pp;
-        pp.e = e;
-        pp.c = -1;
-        pp.r = -1;
-        pp.p = p;
-        _oldPixelPositions.push_back(pp);
-      }
-    }
-  }
-
-  void startFallingAnimation()
-  {
-    // Clear falling pixels list
-    _fallingPixels.clear();
-
-    // Add all pixels that need to fall
-    for (int i = 0; i < _oldPixelPositions.size(); i++) {
-      FallingPixel fp;
-
-      fp.r = _oldPixelPositions[i].r;
-      fp.c = _oldPixelPositions[i].c;
-      fp.e = _oldPixelPositions[i].e;
-
-      fp.cr = -random(3, 20); // Random delay in frames
-      fp.cc = -random(3, 20); // Random delay in frames
-      fp.ce = -random(3, 20); // Random delay in frames
-
-      fp.p = _oldPixelPositions[i].p;
-
-      _fallingPixels.push_back(fp);
-    }
-
-    _animationPhase = 0;
-  }
-
-  void startRisingAnimation()
-  {
-    // Clear rising pixels list
-    _fallingPixels.clear();
-
-    // Create all rising pixels at once based on current input
-    for (int c = 0; c < NCOL; c++) {
-      for (int r = 0; r < NROW; r++) {
-        Pixel targetPixel = _pPixelContainerInput->pixelsArray.getPixel(r, c);
-        if (!targetPixel.display) continue;
-
-        FallingPixel fp;
-        fp.r = r;
-        fp.c = c;
-        fp.e = -1;
-        fp.cr = -random(3, 20); // Random delay in frames
-        fp.cc = -random(3, 20); // Random delay in frames
-        fp.ce = -random(3, 20); // Random delay in frames
-        fp.p = targetPixel;
-
-        _fallingPixels.push_back(fp);
-      }
-    }
-
-    // Handle edge pixels too
-    for (int e = 0; e < NEDGE; e++) {
-      Pixel targetPixel = _pPixelContainerInput->pixelsEdge[e];
-      if (!targetPixel.display) continue;
-
-      FallingPixel fp;
-      fp.r = -1;
-      fp.c = -1;
-      fp.e = e;
-      fp.cr = -random(3, 20); // Random delay in frames
-      fp.cc = -random(3, 20); // Random delay in frames
-      fp.ce = -random(3, 20); // Random delay in frames
-      fp.p = targetPixel;
-
-      _fallingPixels.push_back(fp);
-    }
-
-    _animationPhase = 1;
   }
 
 public:
-  LedStripAnimationMinuteFall(PixelsContainer *pPixelContainerInput, PixelsContainer *pPixelContainerOutput)
-    : LedStripAnimation("PixelsFalling", pPixelContainerInput, pPixelContainerOutput)
-    , _lastMinute(-1)
-    , _animationInProgress(false)
-    , _animationPhase(0)
+  LedStripAnimationLightning(PixelsContainer *pPixelContainerInput, PixelsContainer *pPixelContainerOutput)
+    : LedStripAnimation("Lightning", pPixelContainerInput, pPixelContainerOutput)
+    , _phase(PAUSE), _buildRow(0), _flashTimer(0), _pauseTimer(0), _fadeProgress(0)
   {
+    memset(_boltGrid, 0, sizeof(_boltGrid));
+  }
+
+  void setPauseTimer()
+  {
+    int r = random(10);
+    if (r < 2)      _pauseTimer = 3  + random(12);   // double-flash rapide
+    else if (r < 6) _pauseTimer = 40 + random(80);   // pause normale
+    else            _pauseTimer = 120 + random(200);  // longue attente
   }
 
   void begin()
   {
-    _frame.init(15); // Slow animation (fps)
-    _lastMinute = _dateTime.minute;
-    _animationInProgress = false;
-
-    // Clear falling pixels lists
-    _fallingPixels.clear();
-    //_risingPixels.clear();
-
-    // Force refresh of input pixels because
-    // we copy them to the output buffer only
-    // When they change. (To limit CPU usage)
-    _pPixelContainerInput->hasChanged = true;
+    _frame.init(30.0 * _config.animSpeed / 10.0);
+    _phase = PAUSE;
+    setPauseTimer();
   }
 
   void handle()
@@ -2042,109 +2061,89 @@ public:
     if (!_frame.next())
       return;
 
-    // Check if minute has changed
-    if (_dateTime.minute != _lastMinute && !_animationInProgress) {
-      _lastMinute = _dateTime.minute;
-      _animationInProgress = true;
-      startFallingAnimation();
-    }
-
-    getPixelsList();
-
-    if (!_animationInProgress) {
-      // No animation, just copy input to output
-      *_pPixelContainerOutput = *_pPixelContainerInput;
-      _pPixelContainerOutput->hasChanged = true;
-      return;
-    }
-
     clearPixelsColor();
+    uint8_t bMax = (uint8_t)((uint16_t)_config.animBrightnessMax * 255 / 100);
 
-    if (_animationPhase == 0) {
-      bool allFallen = true;
+    switch (_phase)
+    {
+      case PAUSE:
+        copyForeground();
+        if (--_pauseTimer <= 0) {
+          generateBolt();
+          _buildRow = 0;
+          _phase = BUILD;
+        }
+        break;
 
-      for (int i = 0; i < _fallingPixels.size(); i++) {
-        _fallingPixels[i].cr++;
-
-        // Matrix pixel
-        if (_fallingPixels[i].e == -1) {
-          // If the pixel current position is under the matrix, do nothing (no display)
-          if (_fallingPixels[i].cr > NROW) continue;
-
-          // If the pixel current position is above the original position, display at original position (delay phase)
-          else if (_fallingPixels[i].cr < _fallingPixels[i].r) {
-            _pPixelContainerOutput->pixelsArray.setPixel(_fallingPixels[i].p, _fallingPixels[i].r, _fallingPixels[i].c);
-            allFallen = false;
-          }
-
-          // If the pixel current position is below the original position, display at current position (falling)
-          else {
-            _pPixelContainerOutput->pixelsArray.setPixel(_fallingPixels[i].p, _fallingPixels[i].cr, _fallingPixels[i].c);
-            allFallen = false;
+      case BUILD:
+        _buildRow = min(_buildRow + 2, NROW);
+        for (int r = 0; r < _buildRow; r++) {
+          for (int col = 0; col < NCOL; col++) {
+            if (_boltGrid[r][col]) {
+              Pixel p;
+              p.color = RgbColor(bMax, bMax, bMax);
+              p.display = true;
+              _pPixelContainerOutput->pixelsArray.setPixel(p, r, col);
+            }
           }
         }
+        copyForeground();
+        if (_buildRow >= NROW) {
+          _flashTimer = 3;
+          _phase = FLASH;
+        }
+        break;
 
-        // Edge pixel
-        if (_fallingPixels[i].c == -1 && _fallingPixels[i].r == -1) {
-          // If pixel current position is in delay phase, display it at edge position
-          if (_fallingPixels[i].cr < 0) {
-            _pPixelContainerOutput->pixelsEdge[_fallingPixels[i].e] = _fallingPixels[i].p;
-            allFallen = false;
+      case FLASH:
+      {
+        uint8_t fb = bMax / 2;
+        for (int r = 0; r < NROW; r++) {
+          for (int col = 0; col < NCOL; col++) {
+            Pixel p;
+            p.color = RgbColor(fb, fb, fb);
+            p.display = true;
+            _pPixelContainerOutput->pixelsArray.setPixel(p, r, col);
           }
         }
-      }
-
-      if (allFallen) {
-        // All pixels have fallen, switch to rising phase
-        startRisingAnimation();
-      }
-    }
-
-    if (_animationPhase == 1) {
-      // Second step: rising pixels of new time
-      bool allRisen = true;
-
-      // Animate all rising pixels
-      for (int i = 0; i < _fallingPixels.size(); i++) {
-        _fallingPixels[i].cr++;
-
-        // Matrix pixel
-        if (_fallingPixels[i].e == -1) {
-          // If the pixel current position is in delay phase (above matrix), wait
-          if (_fallingPixels[i].cr < 0) {
-            allRisen = false;
-            continue;
-          }
-
-          // If the pixel current position is falling to destination
-          else if (_fallingPixels[i].cr <= _fallingPixels[i].r) {
-            _pPixelContainerOutput->pixelsArray.setPixel(_fallingPixels[i].p, _fallingPixels[i].cr, _fallingPixels[i].c);
-            allRisen = false;
-          }
-
-          // If the pixel current position has reached its destination
-          else {
-            _pPixelContainerOutput->pixelsArray.setPixel(_fallingPixels[i].p, _fallingPixels[i].r, _fallingPixels[i].c);
-          }
-        }
-
-        // Edge pixel
-        if (_fallingPixels[i].c == -1 && _fallingPixels[i].r == -1) {
-          // If pixel current position is in delay phase, wait
-          if (_fallingPixels[i].cr < 0) {
-            allRisen = false;
-          }
-
-          // Display pixel at edge position (reached destination)
-          else {
-            _pPixelContainerOutput->pixelsEdge[_fallingPixels[i].e] = _fallingPixels[i].p;
-          }
+        for (int e = 0; e < NEDGE; e++) {
+          Pixel p;
+          p.color = RgbColor(fb, fb, fb);
+          p.display = true;
+          _pPixelContainerOutput->pixelsEdge[e] = p;
         }
       }
+        if (--_flashTimer <= 0) {
+          _fadeProgress = 0;
+          _phase = FADE;
+        }
+        break;
 
-      if (allRisen) {
-        // Animation complete
-        _animationInProgress = false;
+      case FADE:
+      {
+        bool anyVisible = false;
+        for (int r = 0; r < NROW; r++) {
+          int bright = 255 - max(0, _fadeProgress - r) * 20;
+          if (bright < 0) bright = 0;
+          if (bright > 0) {
+            anyVisible = true;
+            uint8_t b = (uint8_t)((uint16_t)bright * bMax / 255);
+            for (int col = 0; col < NCOL; col++) {
+              if (_boltGrid[r][col]) {
+                Pixel p;
+                p.color = RgbColor(b, b, b);
+                p.display = true;
+                _pPixelContainerOutput->pixelsArray.setPixel(p, r, col);
+              }
+            }
+          }
+        }
+        copyForeground();
+        _fadeProgress++;
+        if (!anyVisible) {
+          _phase = PAUSE;
+          setPauseTimer();
+        }
+        break;
       }
     }
 
@@ -2152,27 +2151,490 @@ public:
   }
 };
 
+class LedStripAnimationStorm : public LedStripAnimationLightning
+{
+public:
+  LedStripAnimationStorm(PixelsContainer *pPixelContainerInput, PixelsContainer *pPixelContainerOutput)
+    : LedStripAnimationLightning(pPixelContainerInput, pPixelContainerOutput)
+  {
+    _name = "Storm";
+  }
+
+  void handle()
+  {
+    if (!_frame.next())
+      return;
+
+    clearPixelsColor();
+    uint8_t bMax = (uint8_t)((uint16_t)_config.animBrightnessMax * 255 / 100);
+
+    switch (_phase)
+    {
+      case PAUSE:
+        copyForeground();
+        if (--_pauseTimer <= 0) {
+          generateBolt();
+          _buildRow = 0;
+          _phase = BUILD;
+        }
+        break;
+
+      case BUILD:
+        _buildRow = min(_buildRow + 2, NROW);
+        for (int r = 0; r < _buildRow; r++) {
+          for (int col = 0; col < NCOL; col++) {
+            if (_boltGrid[r][col]) {
+              Pixel p;
+              p.color = RgbColor(bMax, bMax, bMax);
+              p.display = true;
+              _pPixelContainerOutput->pixelsArray.setPixel(p, r, col);
+            }
+          }
+        }
+        copyForeground();
+        if (_buildRow >= NROW) {
+          _fadeProgress = 0;
+          _phase = FADE;
+        }
+        break;
+
+      case FLASH:
+        break;
+
+      case FADE:
+      {
+        bool anyVisible = false;
+        for (int r = 0; r < NROW; r++) {
+          int bright = 255 - max(0, _fadeProgress - r) * 20;
+          if (bright < 0) bright = 0;
+          if (bright > 0) {
+            anyVisible = true;
+            uint8_t b = (uint8_t)((uint16_t)bright * bMax / 255);
+            for (int col = 0; col < NCOL; col++) {
+              if (_boltGrid[r][col]) {
+                Pixel p;
+                p.color = RgbColor(b, b, b);
+                p.display = true;
+                _pPixelContainerOutput->pixelsArray.setPixel(p, r, col);
+              }
+            }
+          }
+        }
+        copyForeground();
+        _fadeProgress++;
+        if (!anyVisible) {
+          _phase = PAUSE;
+          setPauseTimer();
+        }
+        break;
+      }
+    }
+
+    _pPixelContainerOutput->hasChanged = true;
+  }
+};
+
+// ---- Tetris ----
+
+static const int8_t TET_PIECES[7][4][4][2] = {
+  // I
+  {{{0,0},{0,1},{0,2},{0,3}}, {{0,2},{1,2},{2,2},{3,2}}, {{0,0},{0,1},{0,2},{0,3}}, {{0,1},{1,1},{2,1},{3,1}}},
+  // O
+  {{{0,1},{0,2},{1,1},{1,2}}, {{0,1},{0,2},{1,1},{1,2}}, {{0,1},{0,2},{1,1},{1,2}}, {{0,1},{0,2},{1,1},{1,2}}},
+  // T
+  {{{0,1},{1,0},{1,1},{1,2}}, {{0,1},{1,1},{1,2},{2,1}}, {{1,0},{1,1},{1,2},{2,1}}, {{0,1},{1,0},{1,1},{2,1}}},
+  // S
+  {{{0,1},{0,2},{1,0},{1,1}}, {{0,1},{1,1},{1,2},{2,2}}, {{0,1},{0,2},{1,0},{1,1}}, {{0,1},{1,1},{1,2},{2,2}}},
+  // Z
+  {{{0,0},{0,1},{1,1},{1,2}}, {{0,2},{1,1},{1,2},{2,1}}, {{0,0},{0,1},{1,1},{1,2}}, {{0,2},{1,1},{1,2},{2,1}}},
+  // J
+  {{{0,0},{1,0},{1,1},{1,2}}, {{0,1},{0,2},{1,1},{2,1}}, {{1,0},{1,1},{1,2},{2,2}}, {{0,1},{1,1},{2,0},{2,1}}},
+  // L
+  {{{0,2},{1,0},{1,1},{1,2}}, {{0,1},{1,1},{2,1},{2,2}}, {{1,0},{1,1},{1,2},{2,0}}, {{0,0},{0,1},{1,1},{2,1}}}
+};
+
+static const RgbColor TET_COLORS[7] = {
+  RgbColor(  0, 200, 200),  // I cyan
+  RgbColor(200, 200,   0),  // O yellow
+  RgbColor(150,   0, 200),  // T purple
+  RgbColor(  0, 200,   0),  // S green
+  RgbColor(200,   0,   0),  // Z red
+  RgbColor(  0,   0, 200),  // J blue
+  RgbColor(200, 100,   0),  // L orange
+};
+
+class LedStripAnimationTetris : public LedStripAnimation
+{
+public:
+  static LedStripAnimationTetris *instance;
+
+  enum TetAction { ACT_NONE=0, ACT_LEFT, ACT_RIGHT, ACT_ROTATE, ACT_DOWN, ACT_DROP, ACT_START };
+  enum TetState  { STATE_IDLE, STATE_PLAYING, STATE_GAME_OVER };
+
+private:
+  Frame    _frame;
+  uint8_t  _board[NROW][NCOL];
+  int8_t   _pieceType, _pieceRot, _pieceRow, _pieceCol, _nextPiece;
+  uint32_t _lastTick, _tickInterval;
+  uint16_t _score;
+  uint8_t  _lines, _level;
+  TetState  _state;
+  TetAction _pendingAction;
+
+  void getCells(int8_t type, int8_t rot, int8_t row, int8_t col, int8_t out[4][2])
+  {
+    for (int i = 0; i < 4; i++) {
+      out[i][0] = row + TET_PIECES[type][rot][i][0];
+      out[i][1] = col + TET_PIECES[type][rot][i][1];
+    }
+  }
+
+  bool canPlace(int8_t type, int8_t rot, int8_t row, int8_t col)
+  {
+    int8_t cells[4][2];
+    getCells(type, rot, row, col, cells);
+    for (int i = 0; i < 4; i++) {
+      int8_t r = cells[i][0], c = cells[i][1];
+      if (r < 0 || r >= NROW || c < 0 || c >= NCOL) return false;
+      if (_board[r][c]) return false;
+    }
+    return true;
+  }
+
+  void clearLines()
+  {
+    uint8_t cleared = 0;
+    for (int r = NROW - 1; r >= 0; r--) {
+      bool full = true;
+      for (int c = 0; c < NCOL; c++) if (!_board[r][c]) { full = false; break; }
+      if (full) {
+        for (int rr = r; rr > 0; rr--) memcpy(_board[rr], _board[rr-1], NCOL);
+        memset(_board[0], 0, NCOL);
+        cleared++; r++;
+      }
+    }
+    if (cleared) {
+      const uint16_t pts[4] = {100, 300, 500, 800};
+      _score += pts[min((int)cleared - 1, 3)] * (_level + 1);
+      _lines += cleared;
+      _level  = _lines / 10;
+      _tickInterval = max(100UL, 800UL - (uint32_t)_level * 70UL);
+    }
+  }
+
+  void spawnPiece(int8_t type)
+  {
+    _pieceType = type;
+    _pieceRot  = 0;
+    _pieceRow  = 0;
+    _pieceCol  = NCOL / 2 - 2;
+    if (!canPlace(_pieceType, _pieceRot, _pieceRow, _pieceCol))
+      _state = STATE_GAME_OVER;
+  }
+
+  void lockPiece()
+  {
+    int8_t cells[4][2];
+    getCells(_pieceType, _pieceRot, _pieceRow, _pieceCol, cells);
+    for (int i = 0; i < 4; i++) {
+      int8_t r = cells[i][0], c = cells[i][1];
+      if (r >= 0 && r < NROW && c >= 0 && c < NCOL)
+        _board[r][c] = _pieceType + 1;
+    }
+    clearLines();
+    spawnPiece(_nextPiece);
+    _nextPiece = random(7);
+  }
+
+  void startGame()
+  {
+    memset(_board, 0, sizeof(_board));
+    _score = 0; _lines = 0; _level = 0; _tickInterval = 800;
+    _nextPiece = random(7);
+    _lastTick  = millis();
+    _state     = STATE_PLAYING;
+    spawnPiece(random(7));
+  }
+
+  void renderBoard()
+  {
+    clearPixelsColor();
+    uint8_t bMax = (uint8_t)((uint16_t)_config.animBrightnessMax * 255 / 100);
+
+    for (int r = 0; r < NROW; r++) {
+      for (int c = 0; c < NCOL; c++) {
+        if (_board[r][c]) {
+          RgbColor col = TET_COLORS[_board[r][c] - 1];
+          Pixel p;
+          p.color = RgbColor(
+            (uint8_t)((uint16_t)col.R * bMax / 512),
+            (uint8_t)((uint16_t)col.G * bMax / 512),
+            (uint8_t)((uint16_t)col.B * bMax / 512));
+          p.display = true;
+          _pPixelContainerOutput->pixelsArray.setPixel(p, r, c);
+        } else if (_state == STATE_GAME_OVER && (millis() / 300) % 2 == 0) {
+          Pixel p; p.display = true;
+          p.color = RgbColor((uint8_t)((uint16_t)200 * bMax / 255), 0, 0);
+          _pPixelContainerOutput->pixelsArray.setPixel(p, r, c);
+        }
+      }
+    }
+
+    if (_state == STATE_PLAYING) {
+      int8_t cells[4][2];
+      getCells(_pieceType, _pieceRot, _pieceRow, _pieceCol, cells);
+      for (int i = 0; i < 4; i++) {
+        int8_t r = cells[i][0], c = cells[i][1];
+        if (r >= 0 && r < NROW && c >= 0 && c < NCOL) {
+          RgbColor col = TET_COLORS[_pieceType];
+          Pixel p;
+          p.color = RgbColor(
+            (uint8_t)((uint16_t)col.R * bMax / 255),
+            (uint8_t)((uint16_t)col.G * bMax / 255),
+            (uint8_t)((uint16_t)col.B * bMax / 255));
+          p.display = true;
+          _pPixelContainerOutput->pixelsArray.setPixel(p, r, c);
+        }
+      }
+    }
+
+    _pPixelContainerOutput->hasChanged = true;
+  }
+
+public:
+  LedStripAnimationTetris(PixelsContainer *in, PixelsContainer *out)
+    : LedStripAnimation("Tetris", in, out)
+    , _pieceType(0), _pieceRot(0), _pieceRow(0), _pieceCol(0), _nextPiece(0)
+    , _lastTick(0), _tickInterval(800)
+    , _score(0), _lines(0), _level(0)
+    , _state(STATE_IDLE), _pendingAction(ACT_NONE)
+  {
+    memset(_board, 0, sizeof(_board));
+    instance = this;
+  }
+
+  void begin()
+  {
+    _frame.init(30.0);
+    startGame();
+  }
+
+  void action(TetAction act) { _pendingAction = act; }
+  TetState getState()        { return _state; }
+  uint16_t getScore()        { return _score; }
+  uint8_t  getLines()        { return _lines; }
+  uint8_t  getLevel()        { return _level; }
+  int8_t   getNext()         { return _nextPiece; }
+
+  void handle()
+  {
+    TetAction act = _pendingAction;
+    _pendingAction = ACT_NONE;
+
+    if (_state == STATE_GAME_OVER) {
+      if (act == ACT_START) startGame();
+    } else if (_state == STATE_PLAYING) {
+      if      (act == ACT_LEFT   && canPlace(_pieceType, _pieceRot, _pieceRow, _pieceCol-1)) _pieceCol--;
+      else if (act == ACT_RIGHT  && canPlace(_pieceType, _pieceRot, _pieceRow, _pieceCol+1)) _pieceCol++;
+      else if (act == ACT_ROTATE) {
+        int8_t nr = (_pieceRot + 1) % 4;
+        if (canPlace(_pieceType, nr, _pieceRow, _pieceCol)) _pieceRot = nr;
+      }
+      else if (act == ACT_DOWN) {
+        if (canPlace(_pieceType, _pieceRot, _pieceRow+1, _pieceCol)) _pieceRow++;
+        else lockPiece();
+        _lastTick = millis();
+      }
+      else if (act == ACT_DROP) {
+        while (canPlace(_pieceType, _pieceRot, _pieceRow+1, _pieceCol)) _pieceRow++;
+        lockPiece();
+        _lastTick = millis();
+      }
+
+      uint32_t now = millis();
+      if (now - _lastTick >= _tickInterval) {
+        _lastTick = now;
+        if (canPlace(_pieceType, _pieceRot, _pieceRow+1, _pieceCol)) _pieceRow++;
+        else lockPiece();
+      }
+    }
+
+    if (_frame.next()) renderBoard();
+  }
+};
+
+LedStripAnimationTetris* LedStripAnimationTetris::instance = nullptr;
+
+class LedStripAnimationSnake : public LedStripAnimation
+{
+public:
+  static LedStripAnimationSnake *instance;
+
+  enum SnaAction { ACT_NONE=0, ACT_UP, ACT_DOWN, ACT_LEFT, ACT_RIGHT, ACT_START };
+  enum SnaState  { STATE_IDLE, STATE_PLAYING, STATE_GAME_OVER };
+  struct Pos { int8_t x, y; };
+
+private:
+  Frame    _frame;
+  Pos      _body[NROW * NCOL];
+  int      _length;
+  int8_t   _dirX, _dirY;
+  int8_t   _nextDirX, _nextDirY;
+  Pos      _food;
+  uint16_t _score;
+  SnaState  _state;
+  uint32_t _lastTick;
+  uint32_t _tickInterval;
+  SnaAction _pendingAction;
+
+  void spawnFood()
+  {
+    Pos free[NROW * NCOL];
+    int nFree = 0;
+    for (int r = 0; r < NROW; r++) {
+      for (int c = 0; c < NCOL; c++) {
+        bool occ = false;
+        for (int i = 0; i < _length; i++)
+          if (_body[i].y == r && _body[i].x == c) { occ = true; break; }
+        if (!occ) free[nFree++] = {(int8_t)c, (int8_t)r};
+      }
+    }
+    if (nFree > 0) _food = free[random(nFree)];
+  }
+
+  void startGame()
+  {
+    _length = 3;
+    _body[0] = {5, 5}; _body[1] = {4, 5}; _body[2] = {3, 5};
+    _dirX = 1; _dirY = 0; _nextDirX = 1; _nextDirY = 0;
+    _score = 0; _tickInterval = 350; _lastTick = millis();
+    _state = STATE_PLAYING;
+    spawnFood();
+  }
+
+  void tick()
+  {
+    _dirX = _nextDirX; _dirY = _nextDirY;
+    int8_t nx = _body[0].x + _dirX;
+    int8_t ny = _body[0].y + _dirY;
+
+    if (nx < 0 || nx >= NCOL || ny < 0 || ny >= NROW) { _state = STATE_GAME_OVER; return; }
+    for (int i = 0; i < _length - 1; i++)
+      if (_body[i].x == nx && _body[i].y == ny) { _state = STATE_GAME_OVER; return; }
+
+    bool ate = (nx == _food.x && ny == _food.y);
+    int newLen = ate ? min(_length + 1, NROW * NCOL) : _length;
+    for (int i = newLen - 1; i > 0; i--) _body[i] = _body[i-1];
+    _body[0] = {nx, ny};
+    _length = newLen;
+    if (ate) {
+      _score += 10;
+      if (_tickInterval > 100) _tickInterval -= 5;
+      spawnFood();
+    }
+  }
+
+  void renderBoard()
+  {
+    clearPixelsColor();
+    uint8_t bMax = (uint8_t)((uint16_t)_config.animBrightnessMax * 255 / 100);
+
+    bool blink = (millis() / 300) % 2 == 0;
+
+    if (_state == STATE_GAME_OVER && blink) {
+      bool occ[NROW][NCOL] = {};
+      for (int i = 0; i < _length; i++) occ[_body[i].y][_body[i].x] = true;
+      Pixel p; p.display = true;
+      p.color = RgbColor((uint8_t)((uint16_t)200 * bMax / 255), 0, 0);
+      for (int r = 0; r < NROW; r++)
+        for (int c = 0; c < NCOL; c++)
+          if (!occ[r][c]) _pPixelContainerOutput->pixelsArray.setPixel(p, r, c);
+    } else if (_state == STATE_PLAYING && blink) {
+      Pixel p; p.display = true;
+      p.color = RgbColor((uint8_t)((uint16_t)255 * bMax / 255), (uint8_t)((uint16_t)80 * bMax / 255), 0);
+      _pPixelContainerOutput->pixelsArray.setPixel(p, _food.y, _food.x);
+    }
+
+    for (int i = _length - 1; i >= 0; i--) {
+      uint8_t g = (i == 0) ? 255 : (uint8_t)max(60, 220 - i * 8);
+      uint8_t b = (i == 0) ? 80  : 0;
+      Pixel p; p.display = true;
+      p.color = RgbColor(0, (uint8_t)((uint16_t)g * bMax / 255), (uint8_t)((uint16_t)b * bMax / 255));
+      _pPixelContainerOutput->pixelsArray.setPixel(p, _body[i].y, _body[i].x);
+    }
+    _pPixelContainerOutput->hasChanged = true;
+  }
+
+public:
+  LedStripAnimationSnake(PixelsContainer *in, PixelsContainer *out)
+    : LedStripAnimation("Snake", in, out)
+    , _length(0), _dirX(1), _dirY(0), _nextDirX(1), _nextDirY(0)
+    , _score(0), _tickInterval(350), _lastTick(0)
+    , _state(STATE_IDLE), _pendingAction(ACT_NONE)
+  { instance = this; }
+
+  void begin() { _frame.init(30.0); startGame(); }
+  void action(SnaAction act) { _pendingAction = act; }
+  SnaState getState() { return _state; }
+  uint16_t getScore() { return _score; }
+
+  void handle()
+  {
+    SnaAction act = _pendingAction;
+    _pendingAction = ACT_NONE;
+
+    if (_state == STATE_GAME_OVER) {
+      if (act == ACT_START) startGame();
+    } else if (_state == STATE_PLAYING) {
+      switch (act) {
+        case ACT_UP:    if (_dirY == 0) { _nextDirX=0;  _nextDirY=-1; } break;
+        case ACT_DOWN:  if (_dirY == 0) { _nextDirX=0;  _nextDirY=1;  } break;
+        case ACT_LEFT:  if (_dirX == 0) { _nextDirX=-1; _nextDirY=0;  } break;
+        case ACT_RIGHT: if (_dirX == 0) { _nextDirX=1;  _nextDirY=0;  } break;
+        default: break;
+      }
+      uint32_t now = millis();
+      if (now - _lastTick >= _tickInterval) { _lastTick = now; tick(); }
+    }
+    if (_frame.next()) renderBoard();
+  }
+};
+
+LedStripAnimationSnake* LedStripAnimationSnake::instance = nullptr;
+
 class MyLedStripAnimator : public MyLedStrip
 {
 protected:
   PixelsContainer _animatedPixels;
   cl_Lst<LedStripAnimation *> _animationList;
   int _animationIndex;
+  LedStripAnimationTetris *_tetrisAnim;
+  bool _tetrisActive;
+  LedStripAnimationSnake *_snakeAnim;
+  bool _snakeActive;
+  int  _savedAnimIndex;
 
   bool handleAnimation()
   {
+    if (_tetrisActive) {
+      if (_animatedPixels.hasChanged) return false;
+      _tetrisAnim->handle();
+      if (_animatedPixels.hasChanged) _pixels.hasChanged = false;
+      return true;
+    }
+    if (_snakeActive) {
+      if (_animatedPixels.hasChanged) return false;
+      _snakeAnim->handle();
+      if (_animatedPixels.hasChanged) _pixels.hasChanged = false;
+      return true;
+    }
+
     if (_animationIndex < 0) return false;
     if (_animationIndex > _animationList.size() - 1) return false;
-
-    // check if the animated pixel buffer is displayed
-    // if not, do not update the animated pixel buffer
     if (_animatedPixels.hasChanged) return false;
 
-    // update the animated pixel buffer
     _animationList[_animationIndex]->handle();
 
-    // if output pixels buffer is updated
-    // then simulate update of the input buffer
     if (_animatedPixels.hasChanged)
       _pixels.hasChanged = false;
 
@@ -2183,6 +2645,9 @@ public:
   MyLedStripAnimator()
     : MyLedStrip()
     , _animationIndex(0)
+    , _tetrisActive(false)
+    , _snakeActive(false)
+    , _savedAnimIndex(0)
   {
     _animationList.push_back(new LedStripAnimationNormal(&_pixels, &_animatedPixels));
     _animationList.push_back(new LedStripAnimationBlink(&_pixels, &_animatedPixels));
@@ -2192,9 +2657,50 @@ public:
     _animationList.push_back(new LedStripAnimationSnowFlake(&_pixels, &_animatedPixels));
     _animationList.push_back(new LedStripAnimationCake(&_pixels, &_animatedPixels));
     _animationList.push_back(new LedStripAnimationLove(&_pixels, &_animatedPixels));
-    _animationList.push_back(new LedStripAnimationRipple(&_pixels, &_animatedPixels));
-    _animationList.push_back(new LedStripAnimationMinuteFall(&_pixels, &_animatedPixels));
+    _animationList.push_back(new LedStripAnimationPulse(&_pixels, &_animatedPixels));
+    _animationList.push_back(new LedStripAnimationSparkle(&_pixels, &_animatedPixels));
+    _animationList.push_back(new LedStripAnimationWave(&_pixels, &_animatedPixels));
+    _animationList.push_back(new LedStripAnimationLightning(&_pixels, &_animatedPixels));
+    _animationList.push_back(new LedStripAnimationStorm(&_pixels, &_animatedPixels));
+    _tetrisAnim = new LedStripAnimationTetris(&_pixels, &_animatedPixels);
+    _snakeAnim  = new LedStripAnimationSnake(&_pixels, &_animatedPixels);
   }
+
+  void tetrisStart()
+  {
+    _savedAnimIndex = _animationIndex;
+    _tetrisActive   = true;
+    _tetrisAnim->begin();
+  }
+
+  void tetrisStop()
+  {
+    _tetrisActive  = false;
+    _animationIndex = _savedAnimIndex;
+    if (_animationIndex >= 0 && _animationIndex < _animationList.size())
+      _animationList[_animationIndex]->begin();
+    _pixels.hasChanged = true;
+  }
+
+  bool isTetrisActive() { return _tetrisActive; }
+
+  void snakeStart()
+  {
+    _savedAnimIndex = _animationIndex;
+    _snakeActive    = true;
+    _snakeAnim->begin();
+  }
+
+  void snakeStop()
+  {
+    _snakeActive    = false;
+    _animationIndex = _savedAnimIndex;
+    if (_animationIndex >= 0 && _animationIndex < _animationList.size())
+      _animationList[_animationIndex]->begin();
+    _pixels.hasChanged = true;
+  }
+
+  bool isSnakeActive() { return _snakeActive; }
 
   bool setAnimation(int mode)
   {
@@ -2207,6 +2713,13 @@ public:
     _mqtt.publish(mqttTopicPubLedAnim.topic().c_str(), String(mode).c_str());
 
     return true;
+  }
+
+  void setAnimSpeed(byte speed)
+  {
+    _config.animSpeed = max((byte)1, min((byte)20, speed));
+    if (_animationIndex >= 0 && _animationIndex < _animationList.size())
+      _animationList[_animationIndex]->begin();
   }
 
   int getAnimationIndex()

--- a/NTP.h
+++ b/NTP.h
@@ -183,7 +183,7 @@ boolean summerTime(unsigned long timeStamp) {
 }
 
 unsigned long adjustTimeZone(unsigned long timeStamp, int timeZone, bool isDayLightSavingSaving) {
-  timeStamp += (long)timeZone * 3600; // adjust timezone (unit = 1/10th hour → seconds)
+  timeStamp += (long)timeZone * 360; // adjust timezone (unit = 1/10th hour, e.g. GMT+1 = value 10)
   if (isDayLightSavingSaving && summerTime(timeStamp)) timeStamp += 3600; // Sommerzeit beachten
   return timeStamp;
 }

--- a/NTP.h
+++ b/NTP.h
@@ -183,7 +183,7 @@ boolean summerTime(unsigned long timeStamp) {
 }
 
 unsigned long adjustTimeZone(unsigned long timeStamp, int timeZone, bool isDayLightSavingSaving) {
-  timeStamp += timeZone * 360; // adjust timezone
+  timeStamp += (long)timeZone * 3600; // adjust timezone (unit = 1/10th hour → seconds)
   if (isDayLightSavingSaving && summerTime(timeStamp)) timeStamp += 3600; // Sommerzeit beachten
   return timeStamp;
 }

--- a/Page_general.h
+++ b/Page_general.h
@@ -73,6 +73,9 @@ void send_general_configuration_values_html()
   values += "colorrandom|" + (String)_config.colorRandom + "|input\n";
   values += "ledconfig|" + (String)_config.ledConfig + "|input\n";
   values += "brightnesssensibility|" + (String)_config.luxSensitivity + "|input\n";
+  values += "animspeed|" + (String)_config.animSpeed + "|input\n";
+  values += "animbrightmin|" + (String)_config.animBrightnessMin + "|input\n";
+  values += "animbrightmax|" + (String)_config.animBrightnessMax + "|input\n";
 
 	_server.send(200, "text/plain", values);
 	//Serial.println(__FUNCTION__); 
@@ -180,9 +183,16 @@ void send_general_led()
         QTLed.setColorRandom((RandomColorMode)_server.arg(i).toInt());
       }
       if (_server.argName(i) == "brightnesssensibility")
-      {
         _config.luxSensitivity = _server.arg(i).toInt();
-      }
+
+      if (_server.argName(i) == "animspeed")
+        _config.animSpeed = constrain(_server.arg(i).toInt(), 1, 20);
+
+      if (_server.argName(i) == "animbrightmin")
+        _config.animBrightnessMin = constrain(_server.arg(i).toInt(), 0, 100);
+
+      if (_server.argName(i) == "animbrightmax")
+        _config.animBrightnessMax = constrain(_server.arg(i).toInt(), 0, 100);
     }
   }
   _server.send(200, "text/plain", "OK");

--- a/Page_general.h
+++ b/Page_general.h
@@ -125,6 +125,11 @@ void send_general_animations_values_html()
   _server.send(200, "text/plain", values);
 }
 
+void send_lang_value_html()
+{
+  _server.send(200, "text/plain", String(_config.language));
+}
+
 void send_general_led()
 {
   if (_server.args() > 0)

--- a/Page_general.h
+++ b/Page_general.h
@@ -186,7 +186,7 @@ void send_general_led()
         _config.luxSensitivity = _server.arg(i).toInt();
 
       if (_server.argName(i) == "animspeed")
-        _config.animSpeed = constrain(_server.arg(i).toInt(), 1, 20);
+        QTLed.setAnimSpeed(constrain(_server.arg(i).toInt(), 1, 20));
 
       if (_server.argName(i) == "animbrightmin")
         _config.animBrightnessMin = constrain(_server.arg(i).toInt(), 0, 100);

--- a/Page_index.h
+++ b/Page_index.h
@@ -43,6 +43,10 @@ const char PAGE_index[] PROGMEM = R"=====(
           <span class="nav-icon">🔄</span>
           <span>Firmware Update</span>
         </button>
+        <button class="nav-item" data-section="scheduler">
+          <span class="nav-icon">&#x23F0;</span>
+          <span>Scheduler</span>
+        </button>
       </div>
     </nav>
 
@@ -430,6 +434,75 @@ const char PAGE_index[] PROGMEM = R"=====(
           </div>
         </section>
 
+        <!-- Scheduler Section -->
+        <section id="scheduler-section" class="content-section">
+          <div class="dashboard-grid">
+            <div class="card">
+              <div class="card-title">Weekly Schedule</div>
+              <div class="form-group">
+                <div class="checkbox-group">
+                  <input type="checkbox" id="schedulerEnabled" class="checkbox" onchange="saveSchedulerEnabled()">
+                  <label for="schedulerEnabled" class="form-label">Enable scheduler (applies each half-hour, overrides general settings)</label>
+                </div>
+              </div>
+              <p style="font-size:0.8rem;color:var(--text-secondary);margin-bottom:0.75rem">Select a rule on the right, then click/drag cells to paint them. Click a painted cell again to erase it.</p>
+              <div id="schedGrid" class="sched-grid-wrap"><div class="loading">Loading...</div></div>
+            </div>
+            <div class="card sched-editor">
+              <div class="card-title">Rules</div>
+              <div id="schedRulesList" style="margin-bottom:0.4rem"></div>
+              <button class="btn btn-secondary btn-block" onclick="schedAddRule()" style="margin-bottom:0.4rem">+ New rule</button>
+              <hr style="border:none;border-top:1px solid var(--border);margin-bottom:0.4rem">
+              <div class="form-group">
+                <label class="form-label">Display mode</label>
+                <select id="schedMode" class="form-control" onchange="schedEditorChange()"></select>
+              </div>
+              <div class="form-group">
+                <label class="form-label">Color</label>
+                <input type="color" id="schedColor" value="#ffffff" class="form-control" style="height:2rem;padding:0.1rem;cursor:pointer" onchange="schedEditorChange()">
+              </div>
+              <div class="form-group">
+                <label class="form-label">Color randomization</label>
+                <select id="schedColorRandom" class="form-control" onchange="schedEditorChange()">
+                  <option value="0">No Random</option>
+                  <option value="1">Random all</option>
+                  <option value="2">Random letter</option>
+                  <option value="3">Random word</option>
+                </select>
+              </div>
+              <div class="form-group">
+                <label class="form-label">Animation</label>
+                <select id="schedAnimation" class="form-control" onchange="schedEditorChange()"></select>
+              </div>
+              <div class="form-group">
+                <label class="form-label">Speed (1=slow, 20=fast)</label>
+                <div class="range-group">
+                  <input type="range" id="schedAnimSpeed" class="range-input" min="1" max="20" step="1" oninput="document.getElementById('schedAnimSpeedT').textContent=this.value;schedEditorChange()">
+                  <div class="range-value" id="schedAnimSpeedT">10</div>
+                </div>
+              </div>
+              <div class="form-group">
+                <label class="form-label">Min brightness (%)</label>
+                <div class="range-group">
+                  <input type="range" id="schedAnimBrightMin" class="range-input" min="0" max="100" step="1" oninput="document.getElementById('schedAnimBrightMinT').textContent=this.value;schedEditorChange()">
+                  <div class="range-value" id="schedAnimBrightMinT">10</div>
+                </div>
+              </div>
+              <div class="form-group">
+                <label class="form-label">Max brightness (%)</label>
+                <div class="range-group">
+                  <input type="range" id="schedAnimBrightMax" class="range-input" min="0" max="100" step="1" oninput="document.getElementById('schedAnimBrightMaxT').textContent=this.value;schedEditorChange()">
+                  <div class="range-value" id="schedAnimBrightMaxT">100</div>
+                </div>
+              </div>
+              <div style="display:flex;gap:0.5rem;margin-top:0.5rem">
+                <button class="btn btn-secondary" onclick="schedRaz()" style="flex:1">RAZ</button>
+                <button class="btn btn-primary" id="schedSaveBtn" onclick="saveAllScheduler()" style="flex:2">Save</button>
+              </div>
+            </div>
+          </div>
+        </section>
+
         <!-- Update Section -->
         <section id="update-section" class="content-section">
           <div class="dashboard-grid">
@@ -516,7 +589,8 @@ const char PAGE_index[] PROGMEM = R"=====(
       'network': 'Network Configuration',
       'ntp': 'Time Configuration',
       'mqtt': 'MQTT Configuration',
-      'update': 'Firmware Update'
+      'update': 'Firmware Update',
+      'scheduler': 'Display Scheduler'
     };
 
     // Utility functions
@@ -638,6 +712,9 @@ const char PAGE_index[] PROGMEM = R"=====(
           break;
         case 'mqtt':
           loadMqttSettings();
+          break;
+        case 'scheduler':
+          loadSchedulerSettings();
           break;
       }
     }
@@ -1198,6 +1275,267 @@ const char PAGE_index[] PROGMEM = R"=====(
         closeMobileMenu();
       }
     });
+
+    // ── Scheduler ──────────────────────────────────────────────────────────────
+    function toHex2(v){var h=Math.round(v).toString(16);return h.length<2?'0'+h:h;}
+    function schedTextColor(r,g,b){return (r*299+g*587+b*114)/1000>128?'#111':'#fff';}
+    var schedCells=new Array(336).fill(null);
+    var schedRules=[];
+    var schedCurrentRule=0;
+    var schedModeNames=[],schedAnimNames=[];
+    var schedDragging=false,schedDragMode=null;
+
+    function schedEditorChange() {
+      if(!schedRules.length) return;
+      var r=schedRules[schedCurrentRule];
+      r.mode=parseInt(document.getElementById('schedMode').value);
+      r.anim=parseInt(document.getElementById('schedAnimation').value);
+      r.colorRandom=parseInt(document.getElementById('schedColorRandom').value);
+      r.animSpeed=parseInt(document.getElementById('schedAnimSpeed').value);
+      r.animBrightMin=parseInt(document.getElementById('schedAnimBrightMin').value);
+      r.animBrightMax=parseInt(document.getElementById('schedAnimBrightMax').value);
+      var ch=document.getElementById('schedColor').value.replace('#','');
+      r.r=parseInt(ch.substr(0,2),16)||0;
+      r.g=parseInt(ch.substr(2,2),16)||0;
+      r.b=parseInt(ch.substr(4,2),16)||0;
+      schedRenderRulesList();
+      var hex='#'+toHex2(r.r)+toHex2(r.g)+toHex2(r.b);
+      var tc=schedTextColor(r.r,r.g,r.b);
+      document.querySelectorAll('#schedGrid .sched-half.sched-cur').forEach(function(el){
+        el.style.background=hex; el.style.color=tc;
+      });
+    }
+
+    function schedLoadEditor(rule) {
+      document.getElementById('schedMode').value=rule.mode;
+      document.getElementById('schedColorRandom').value=rule.colorRandom;
+      document.getElementById('schedAnimation').value=rule.anim;
+      document.getElementById('schedAnimSpeed').value=rule.animSpeed;
+      document.getElementById('schedAnimSpeedT').textContent=rule.animSpeed;
+      document.getElementById('schedAnimBrightMin').value=rule.animBrightMin;
+      document.getElementById('schedAnimBrightMinT').textContent=rule.animBrightMin;
+      document.getElementById('schedAnimBrightMax').value=rule.animBrightMax;
+      document.getElementById('schedAnimBrightMaxT').textContent=rule.animBrightMax;
+      document.getElementById('schedColor').value='#'+toHex2(rule.r)+toHex2(rule.g)+toHex2(rule.b);
+    }
+
+    function schedRenderRulesList() {
+      var el=document.getElementById('schedRulesList');
+      var crNames=['no random','rnd all','rnd letter','rnd word'];
+      var html='';
+      schedRules.forEach(function(rule,i){
+        var ledHex='#'+toHex2(rule.r)+toHex2(rule.g)+toHex2(rule.b);
+        var mname=schedModeNames[rule.mode]||'mode '+rule.mode;
+        var crname=crNames[rule.colorRandom]||'';
+        var aname=schedAnimNames[rule.anim]||'anim '+rule.anim;
+        var label=mname+' - '+crname+' - '+aname;
+        var active=i===schedCurrentRule;
+        html+='<div class="sched-rule-item'+(active?' sched-rule-active':'')+'" onclick="schedSelectRule('+i+')">'
+          +'<div class="sched-rule-num">'+(i+1)+'</div>'
+          +'<div style="flex:1;font-size:0.8rem">'+label+'</div>'
+          +'<div class="sched-rule-led" style="background:'+ledHex+'" title="LED color"></div>'
+          +'<button class="sched-rule-del" onclick="event.stopPropagation();schedDelRule('+i+')" title="Delete">&#x2715;</button>'
+          +'</div>';
+      });
+      el.innerHTML=html;
+    }
+
+    function schedSelectRule(idx) {
+      schedCurrentRule=idx;
+      schedLoadEditor(schedRules[idx]);
+      schedRenderRulesList();
+      renderSchedulerGrid();
+    }
+
+    function schedAddRule() {
+      schedRules.push({mode:0,anim:0,colorRandom:0,animSpeed:10,animBrightMin:10,animBrightMax:100,r:0,g:0,b:0});
+      schedSelectRule(schedRules.length-1);
+    }
+
+    function schedDelRule(idx) {
+      if(schedRules.length<=1) return;
+      schedRules.splice(idx,1);
+      for(var i=0;i<336;i++){
+        if(schedCells[i]===idx) schedCells[i]=null;
+        else if(schedCells[i]>idx) schedCells[i]--;
+      }
+      if(schedCurrentRule>=schedRules.length) schedCurrentRule=schedRules.length-1;
+      schedLoadEditor(schedRules[schedCurrentRule]);
+      schedRenderRulesList();
+      renderSchedulerGrid();
+    }
+
+    function renderSchedulerGrid() {
+      var days=['Mon','Tue','Wed','Thu','Fri','Sat','Sun'];
+      var html='<table class="sched-table"><thead><tr><th></th>';
+      days.forEach(function(d){html+='<th>'+d+'</th>';});
+      html+='</tr></thead><tbody>';
+      for(var h=0;h<24;h++){
+        html+='<tr><td class="sched-hour">'+(h<10?'0':'')+h+'h</td>';
+        for(var d=0;d<7;d++){
+          html+='<td class="sched-cell">';
+          for(var m=0;m<2;m++){
+            var idx=d*48+h*2+m;
+            var ri=schedCells[idx];
+            var style='',label='';
+            if(ri!==null&&ri!==undefined){
+              var rr=schedRules[ri];
+              style='background:#'+toHex2(rr.r)+toHex2(rr.g)+toHex2(rr.b)+';color:'+schedTextColor(rr.r,rr.g,rr.b)+';';
+              label=String(ri+1);
+            }
+            var isCur=(ri===schedCurrentRule)?'sched-cur':'';
+            html+='<div class="sched-half '+isCur+'" data-d="'+d+'" data-h="'+h+'" data-m="'+(m*30)+'" style="'+style+'">'+label+'</div>';
+          }
+          html+='</td>';
+        }
+        html+='</tr>';
+      }
+      html+='</tbody></table>';
+      document.getElementById('schedGrid').innerHTML=html;
+      schedInitGridEvents();
+    }
+
+    function schedCellAt(el) {
+      var c=el&&el.closest?el.closest('[data-d]'):null;
+      if(!c||!c.classList.contains('sched-half')) return null;
+      var d=parseInt(c.dataset.d),h=parseInt(c.dataset.h),m=parseInt(c.dataset.m);
+      return {el:c,idx:d*48+h*2+(m>=30?1:0)};
+    }
+
+    function schedPaintEl(info) {
+      var ri=schedCells[info.idx];
+      if(ri!==null&&ri!==undefined){
+        var rr=schedRules[ri];
+        info.el.style.background='#'+toHex2(rr.r)+toHex2(rr.g)+toHex2(rr.b);
+        info.el.style.color=schedTextColor(rr.r,rr.g,rr.b);
+        info.el.textContent=String(ri+1);
+        info.el.className='sched-half'+(ri===schedCurrentRule?' sched-cur':'');
+      } else {
+        info.el.style.cssText='';
+        info.el.textContent='';
+        info.el.className='sched-half';
+      }
+    }
+
+    function schedInitGridEvents() {
+      var grid=document.getElementById('schedGrid');
+      if(!grid||grid._ei) return;
+      grid._ei=true;
+      function ptInfo(x,y){return schedCellAt(document.elementFromPoint(x,y));}
+      function onStart(x,y){
+        var info=ptInfo(x,y); if(!info) return;
+        schedDragging=true;
+        schedDragMode=(schedCells[info.idx]===schedCurrentRule)?'remove':'add';
+        schedCells[info.idx]=schedDragMode==='add'?schedCurrentRule:null;
+        schedPaintEl(info);
+      }
+      function onMove(x,y){
+        if(!schedDragging) return;
+        var info=ptInfo(x,y); if(!info) return;
+        if(schedDragMode==='add'&&schedCells[info.idx]!==schedCurrentRule){
+          schedCells[info.idx]=schedCurrentRule; schedPaintEl(info);
+        } else if(schedDragMode==='remove'&&schedCells[info.idx]!==null){
+          schedCells[info.idx]=null; schedPaintEl(info);
+        }
+      }
+      function onEnd(){schedDragging=false;schedDragMode=null;}
+      grid.addEventListener('mousedown',function(e){onStart(e.clientX,e.clientY);e.preventDefault();});
+      document.addEventListener('mousemove',function(e){onMove(e.clientX,e.clientY);});
+      document.addEventListener('mouseup',onEnd);
+      grid.addEventListener('touchstart',function(e){onStart(e.touches[0].clientX,e.touches[0].clientY);e.preventDefault();},{passive:false});
+      document.addEventListener('touchmove',function(e){if(schedDragging){onMove(e.touches[0].clientX,e.touches[0].clientY);e.preventDefault();}},{passive:false});
+      document.addEventListener('touchend',onEnd);
+    }
+
+    function schedRaz() {
+      if(!confirm('Clear all scheduled slots?')) return;
+      schedCells=new Array(336).fill(null);
+      renderSchedulerGrid();
+    }
+
+    function loadSchedulerSettings() {
+      setValues('/admin/schedulerconfig')
+        .then(function(){
+          return fetch('/admin/generalmodesvalues').then(function(r){return r.text();}).then(function(txt){
+            schedModeNames=[];
+            txt.split('\n').forEach(function(l){var p=l.split('|');if(p.length>=2&&p[1])schedModeNames.push(p[1]);});
+          });
+        })
+        .then(function(){
+          return fetch('/admin/generalanimationsvalues').then(function(r){return r.text();}).then(function(txt){
+            schedAnimNames=[];
+            txt.split('\n').forEach(function(l){var p=l.split('|');if(p.length>=2&&p[1])schedAnimNames.push(p[1]);});
+            var ms=document.getElementById('schedMode');ms.innerHTML='';
+            schedModeNames.forEach(function(n,i){var o=document.createElement('option');o.value=i;o.textContent=n;ms.appendChild(o);});
+            var as=document.getElementById('schedAnimation');as.innerHTML='';
+            schedAnimNames.forEach(function(n,i){var o=document.createElement('option');o.value=i;o.textContent=n;as.appendChild(o);});
+          });
+        })
+        .then(function(){
+          return fetch('/admin/schedulerdata').then(function(r){return r.text();}).then(function(txt){
+            schedCells=new Array(336).fill(null);
+            schedRules=[];
+            var ruleMap={};
+            for(var i=0;i<336;i++){
+              var hex=txt.substr(i*16,16);
+              if(hex.length<16) continue;
+              var b0=parseInt(hex.substr(0,2),16);
+              if(b0===0xFF) continue;
+              var key=hex;
+              if(ruleMap[key]===undefined){
+                var b1=parseInt(hex.substr(2,2),16);
+                var b2=parseInt(hex.substr(4,2),16);
+                ruleMap[key]=schedRules.length;
+                schedRules.push({
+                  mode:b0,anim:b1,
+                  colorRandom:b2&0x03,animSpeed:((b2>>2)&0x1F)+1,
+                  animBrightMin:parseInt(hex.substr(6,2),16),
+                  animBrightMax:parseInt(hex.substr(8,2),16),
+                  r:parseInt(hex.substr(10,2),16),
+                  g:parseInt(hex.substr(12,2),16),
+                  b:parseInt(hex.substr(14,2),16)
+                });
+              }
+              schedCells[i]=ruleMap[key];
+            }
+            if(!schedRules.length) schedRules.push({mode:1,anim:0,colorRandom:0,animSpeed:10,animBrightMin:10,animBrightMax:100,r:255,g:255,b:255});
+            schedCurrentRule=0;
+            schedLoadEditor(schedRules[0]);
+            schedRenderRulesList();
+            renderSchedulerGrid();
+          });
+        });
+    }
+
+    function saveSchedulerEnabled() {
+      var en=document.getElementById('schedulerEnabled').checked?'1':'0';
+      fetch('/admin/save/schedulerenabled',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:'enabled='+en});
+    }
+
+    async function saveAllScheduler() {
+      var btn=document.getElementById('schedSaveBtn');
+      setSaveButtonState(btn,'saving');
+      try {
+        var hex='';
+        for(var i=0;i<336;i++){
+          var ri=schedCells[i];
+          if(ri===null||ri===undefined){
+            hex+='FFFFFFFFFFFFFFFF';
+          } else {
+            var rule=schedRules[ri];
+            var packed=(rule.colorRandom&0x03)|((rule.animSpeed-1)<<2);
+            hex+=toHex2(rule.mode)+toHex2(rule.anim)+toHex2(packed)
+                +toHex2(rule.animBrightMin)+toHex2(rule.animBrightMax)
+                +toHex2(rule.r)+toHex2(rule.g)+toHex2(rule.b);
+          }
+        }
+        await fetch('/admin/save/schedulerbulk',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:'data='+hex});
+        await fetch('/admin/scheduler/apply',{method:'POST'});
+        setSaveButtonState(btn,'success');
+      } catch(e){setSaveButtonState(btn,'error');}
+    }
+    // ── End Scheduler ──────────────────────────────────────────────────────────
+
   </script>
 </body>
 </html>

--- a/Page_index.h
+++ b/Page_index.h
@@ -1089,6 +1089,10 @@ const char PAGE_index[] PROGMEM = R"=====(
           removeDuplicateOptions(document.getElementById('lang'));
           removeDuplicateOptions(document.getElementById('mode'));
           removeDuplicateOptions(document.getElementById('animation'));
+          // Sync slider display values (setValues doesn't fire oninput)
+          document.getElementById('animspeedt').textContent = document.getElementById('animspeed').value;
+          document.getElementById('animbrightmint').textContent = document.getElementById('animbrightmin').value;
+          document.getElementById('animbrightmaxt').textContent = document.getElementById('animbrightmax').value;
           // Initialize color picker after values are loaded
           initializeColorPicker();
         });

--- a/Page_index.h
+++ b/Page_index.h
@@ -43,6 +43,14 @@ const char PAGE_index[] PROGMEM = R"=====(
           <span class="nav-icon">🔄</span>
           <span>Firmware Update</span>
         </button>
+        <a class="nav-item" href="/tetris.html" style="text-decoration:none;">
+          <span class="nav-icon">🎮</span>
+          <span>Tetris</span>
+        </a>
+        <a class="nav-item" href="/snake.html" style="text-decoration:none;">
+          <span class="nav-icon">🐍</span>
+          <span>Snake</span>
+        </a>
       </div>
     </nav>
 
@@ -216,6 +224,30 @@ const char PAGE_index[] PROGMEM = R"=====(
                   <label for="animation" class="form-label">Animation</label>
                   <select id="animation" name="animation" class="form-control" onchange="updateanimation()">
                   </select>
+                </div>
+
+                <div class="form-group">
+                  <label for="animspeed" class="form-label">Animation speed (1=slow, 20=fast)</label>
+                  <div class="range-group">
+                    <input type="range" id="animspeed" name="animspeed" class="range-input" min="1" max="20" step="1" oninput="updateanimspeed()">
+                    <div class="range-value" id="animspeedt">--</div>
+                  </div>
+                </div>
+
+                <div class="form-group">
+                  <label for="animbrightmin" class="form-label">Animation min brightness (%)</label>
+                  <div class="range-group">
+                    <input type="range" id="animbrightmin" name="animbrightmin" class="range-input" min="0" max="100" step="1" oninput="updateanimbrightmin()">
+                    <div class="range-value" id="animbrightmint">--</div>
+                  </div>
+                </div>
+
+                <div class="form-group">
+                  <label for="animbrightmax" class="form-label">Animation max brightness (%)</label>
+                  <div class="range-group">
+                    <input type="range" id="animbrightmax" name="animbrightmax" class="range-input" min="0" max="100" step="1" oninput="updateanimbrightmax()">
+                    <div class="range-value" id="animbrightmaxt">--</div>
+                  </div>
                 </div>
 
                 <button type="submit" class="btn btn-primary btn-block">Save Configuration</button>
@@ -778,6 +810,24 @@ const char PAGE_index[] PROGMEM = R"=====(
 
     function updateanimation() {
       setValues("/admin/led?animation=" + document.getElementById("animation").value);
+    }
+
+    function updateanimspeed() {
+      const value = document.getElementById("animspeed").value;
+      document.getElementById("animspeedt").textContent = value;
+      debouncedUpdate("animspeed", value);
+    }
+
+    function updateanimbrightmin() {
+      const value = document.getElementById("animbrightmin").value;
+      document.getElementById("animbrightmint").textContent = value;
+      debouncedUpdate("animbrightmin", value);
+    }
+
+    function updateanimbrightmax() {
+      const value = document.getElementById("animbrightmax").value;
+      document.getElementById("animbrightmaxt").textContent = value;
+      debouncedUpdate("animbrightmax", value);
     }
 
     function validatebrightnessauto() {

--- a/Page_index.h
+++ b/Page_index.h
@@ -781,6 +781,15 @@ const char PAGE_index[] PROGMEM = R"=====(
 
     function initializeColorPicker() {
       initColorPicker();
+      // setValues() sets colorText.value programmatically (no 'input' event fires),
+      // so we push the loaded color into colorInput here explicitly.
+      const colorInput = document.getElementById('color');
+      const colorText  = document.getElementById('colorText');
+      if (colorInput && colorText && colorText.value) {
+        let v = colorText.value.trim();
+        if (!v.startsWith('#')) v = '#' + v;
+        if (isValidHexColor(v)) colorInput.value = v;
+      }
     }
 
     function hexToRgb(hex) {

--- a/Page_index.h
+++ b/Page_index.h
@@ -1444,6 +1444,10 @@ const char PAGE_index[] PROGMEM = R"=====(
           removeDuplicateOptions(document.getElementById('lang'));
           removeDuplicateOptions(document.getElementById('mode'));
           removeDuplicateOptions(document.getElementById('animation'));
+          // Sync slider display values (setValues doesn't fire oninput)
+          document.getElementById('animspeedt').textContent = document.getElementById('animspeed').value;
+          document.getElementById('animbrightmint').textContent = document.getElementById('animbrightmin').value;
+          document.getElementById('animbrightmaxt').textContent = document.getElementById('animbrightmax').value;
           initializeColorPicker();
           // Sync language from loaded value and re-apply translations
           var langEl = document.getElementById('lang');

--- a/Page_index.h
+++ b/Page_index.h
@@ -21,31 +21,31 @@ const char PAGE_index[] PROGMEM = R"=====(
       <div class="sidebar-nav">
         <button class="nav-item active" data-section="info">
           <span class="nav-icon">ℹ</span>
-          <span>System Information</span>
+          <span data-i18n="nav.info">System Information</span>
         </button>
         <button class="nav-item" data-section="general">
           <span class="nav-icon">⚙</span>
-          <span>General Settings</span>
+          <span data-i18n="nav.general">General Settings</span>
         </button>
         <button class="nav-item" data-section="network">
           <span class="nav-icon">📶</span>
-          <span>Network Configuration</span>
+          <span data-i18n="nav.network">Network Configuration</span>
         </button>
         <button class="nav-item" data-section="ntp">
           <span class="nav-icon">🕐</span>
-          <span>Time Configuration</span>
+          <span data-i18n="nav.ntp">Time Configuration</span>
         </button>
         <button class="nav-item" data-section="mqtt">
           <span class="nav-icon">📡</span>
-          <span>MQTT Configuration</span>
+          <span data-i18n="nav.mqtt">MQTT Configuration</span>
         </button>
         <button class="nav-item" data-section="update">
           <span class="nav-icon">🔄</span>
-          <span>Firmware Update</span>
+          <span data-i18n="nav.update">Firmware Update</span>
         </button>
         <button class="nav-item" data-section="scheduler">
           <span class="nav-icon">&#x23F0;</span>
-          <span>Scheduler</span>
+          <span data-i18n="nav.scheduler">Scheduler</span>
         </button>
         <a class="nav-item" href="/tetris.html" style="text-decoration:none;">
           <span class="nav-icon">🎮</span>
@@ -76,58 +76,58 @@ const char PAGE_index[] PROGMEM = R"=====(
         <section id="info-section" class="content-section active">
           <div class="dashboard-grid">
             <div class="card">
-              <div class="card-title">System Status</div>
+              <div class="card-title" data-i18n="card.system_status">System Status</div>
               <div class="status-grid">
                 <div class="status-item">
-                  <div class="status-label">Current Date</div>
+                  <div class="status-label" data-i18n="lbl.current_date">Current Date</div>
                   <div class="status-value" id="x_date">Loading...</div>
                 </div>
                 <div class="status-item">
-                  <div class="status-label">Uptime</div>
+                  <div class="status-label" data-i18n="lbl.uptime">Uptime</div>
                   <div class="status-value" id="x_boot">Loading...</div>
                 </div>
                 <div class="status-item">
-                  <div class="status-label">Firmware Build</div>
+                  <div class="status-label" data-i18n="lbl.firmware_build">Firmware Build</div>
                   <div class="status-value" id="x_version">Loading...</div>
                 </div>
               </div>
             </div>
 
             <div class="card">
-              <div class="card-title">Network Information</div>
+              <div class="card-title" data-i18n="card.network_info">Network Information</div>
               <div class="status-grid">
                 <div class="status-item">
-                  <div class="status-label">WiFi Network</div>
+                  <div class="status-label" data-i18n="lbl.wifi_network">WiFi Network</div>
                   <div class="status-value" id="x_ssid">Loading...</div>
                 </div>
                 <div class="status-item">
-                  <div class="status-label">Signal Strength</div>
+                  <div class="status-label" data-i18n="lbl.signal_strength">Signal Strength</div>
                   <div class="status-value"><span id="x_rssi">-</span>%</div>
                 </div>
                 <div class="status-item">
-                  <div class="status-label">IP Address</div>
+                  <div class="status-label" data-i18n="lbl.ip_address">IP Address</div>
                   <div class="status-value" id="x_ip">Loading...</div>
                 </div>
                 <div class="status-item">
-                  <div class="status-label">MAC Address</div>
+                  <div class="status-label" data-i18n="lbl.mac_address">MAC Address</div>
                   <div class="status-value" id="x_mac">Loading...</div>
                 </div>
               </div>
             </div>
 
             <div class="card">
-              <div class="card-title">Sensor Readings</div>
+              <div class="card-title" data-i18n="card.sensors">Sensor Readings</div>
               <div class="status-grid">
                 <div class="status-item">
-                  <div class="status-label">Ambient Light</div>
+                  <div class="status-label" data-i18n="lbl.ambient_light">Ambient Light</div>
                   <div class="status-value"><span id="x_als">-</span> lux</div>
                 </div>
                 <div class="status-item">
-                  <div class="status-label">Display Brightness</div>
+                  <div class="status-label" data-i18n="lbl.display_brightness">Display Brightness</div>
                   <div class="status-value" id="x_brightness">-</div>
                 </div>
                 <div class="status-item">
-                  <div class="status-label">Temperature</div>
+                  <div class="status-label" data-i18n="lbl.temperature">Temperature</div>
                   <div class="status-value"><span id="x_temp">-</span> °C</div>
                 </div>
               </div>
@@ -139,29 +139,29 @@ const char PAGE_index[] PROGMEM = R"=====(
         <section id="general-section" class="content-section">
           <div class="dashboard-grid">
             <div class="card">
-              <div class="card-title">Brightness Control</div>
+              <div class="card-title" data-i18n="card.brightness">Brightness Control</div>
               <form id="general-form" onsubmit="return saveGeneralSettings(event)">
 
             <div class="form-group">
               <div class="checkbox-group">
                 <input type="checkbox" id="brightnessauto" name="brightnessauto" class="checkbox" onchange="updatebrightnessauto()">
-                <label for="brightnessauto" class="form-label">Automatic brightness</label>
+                <label for="brightnessauto" class="form-label" data-i18n="lbl.auto_brightness">Automatic brightness</label>
               </div>
             </div>
 
             <div class="form-group">
-              <label for="brightnesssensibility" class="form-label">Brightness sensitivity</label>
+              <label for="brightnesssensibility" class="form-label" data-i18n="lbl.brightness_sensitivity">Brightness sensitivity</label>
               <select id="brightnesssensibility" name="brightnesssensibility" class="form-control" onchange="updatebrightnesssensibility()">
-                <option value="10">Very high</option>
-                <option value="20">High</option>
-                <option value="30">Normal</option>
-                <option value="40">Low</option>
-                <option value="50">Very low</option>
+                <option value="10" data-i18n="opt.very_high">Very high</option>
+                <option value="20" data-i18n="opt.high">High</option>
+                <option value="30" data-i18n="opt.normal">Normal</option>
+                <option value="40" data-i18n="opt.low">Low</option>
+                <option value="50" data-i18n="opt.very_low">Very low</option>
               </select>
             </div>
 
             <div class="form-group">
-              <label for="brightness" class="form-label">Manual brightness</label>
+              <label for="brightness" class="form-label" data-i18n="lbl.manual_brightness">Manual brightness</label>
               <div class="range-group">
                 <input type="range" id="brightness" name="brightness" class="range-input" max="255" min="0" step="1" oninput="updatebrightness()">
                 <div class="range-value" id="brightnesst">--</div>
@@ -169,7 +169,7 @@ const char PAGE_index[] PROGMEM = R"=====(
             </div>
 
             <div class="form-group">
-              <label for="brightnessday" class="form-label">Minimum day brightness</label>
+              <label for="brightnessday" class="form-label" data-i18n="lbl.day_brightness">Minimum day brightness</label>
               <div class="range-group">
                 <input type="range" id="brightnessday" name="brightnessday" class="range-input" max="255" min="0" step="1" oninput="updatebrightnessday()">
                 <div class="range-value" id="brightnessdayt">--</div>
@@ -177,7 +177,7 @@ const char PAGE_index[] PROGMEM = R"=====(
             </div>
 
             <div class="form-group">
-              <label for="brightnessnight" class="form-label">Minimum night brightness</label>
+              <label for="brightnessnight" class="form-label" data-i18n="lbl.night_brightness">Minimum night brightness</label>
               <div class="range-group">
                 <input type="range" id="brightnessnight" name="brightnessnight" class="range-input" max="255" min="0" step="1" oninput="updatebrightnessnight()">
                 <div class="range-value" id="brightnessnightt">--</div>
@@ -186,16 +186,16 @@ const char PAGE_index[] PROGMEM = R"=====(
           </div>
 
             <div class="card">
-              <div class="card-title">Display Configuration</div>
+              <div class="card-title" data-i18n="card.display_config">Display Configuration</div>
 
               <div class="form-group">
-                <label for="ledconfig" class="form-label">Clock type</label>
+                <label for="ledconfig" class="form-label" data-i18n="lbl.clock_type">Clock type</label>
                 <select id="ledconfig" name="ledconfig" class="form-control">
                 </select>
               </div>
 
             <div class="form-group">
-              <label class="form-label">Color</label>
+              <label class="form-label" data-i18n="lbl.color">Color</label>
               <div style="display:flex;gap:0.75rem;align-items:center">
                 <div id="colorSwatch" class="cpicker-swatch" title="Pick color" style="width:3rem;height:2.5rem;background:#ff0000;border:2px solid #ccc;border-radius:4px;cursor:pointer;flex-shrink:0"></div>
                 <input type="text" id="colorText" class="color-text-input" placeholder="#FF0000" maxlength="7">
@@ -212,35 +212,35 @@ const char PAGE_index[] PROGMEM = R"=====(
             </div>
 
             <div class="form-group">
-              <label for="colorrandom" class="form-label">Color randomization</label>
+              <label for="colorrandom" class="form-label" data-i18n="lbl.color_random">Color randomization</label>
               <select id="colorrandom" name="colorrandom" class="form-control" onchange="updatecolorrandom()">
-                <option value="0">No Random</option>
-                <option value="1">Random all</option>
-                <option value="2">Random letter</option>
-                <option value="3">Random word</option>
+                <option value="0" data-i18n="opt.no_random">No Random</option>
+                <option value="1" data-i18n="opt.random_all">Random all</option>
+                <option value="2" data-i18n="opt.random_letter">Random letter</option>
+                <option value="3" data-i18n="opt.random_word">Random word</option>
               </select>
             </div>
 
             <div class="form-group">
-              <label for="lang" class="form-label">Language</label>
+              <label for="lang" class="form-label" data-i18n="lbl.language">Language</label>
               <select id="lang" name="lang" class="form-control" onchange="updatelang()">
               </select>
             </div>
 
             <div class="form-group">
-              <label for="mode" class="form-label">Display mode</label>
+              <label for="mode" class="form-label" data-i18n="lbl.display_mode">Display mode</label>
               <select id="mode" name="mode" class="form-control" onchange="updatemode()">
               </select>
             </div>
 
                 <div class="form-group">
-                  <label for="animation" class="form-label">Animation</label>
+                  <label for="animation" class="form-label" data-i18n="lbl.animation">Animation</label>
                   <select id="animation" name="animation" class="form-control" onchange="updateanimation()">
                   </select>
                 </div>
 
                 <div class="form-group">
-                  <label for="animspeed" class="form-label">Animation speed (1=slow, 20=fast)</label>
+                  <label for="animspeed" class="form-label" data-i18n="lbl.anim_speed">Animation speed (1=slow, 20=fast)</label>
                   <div class="range-group">
                     <input type="range" id="animspeed" name="animspeed" class="range-input" min="1" max="20" step="1" oninput="updateanimspeed()">
                     <div class="range-value" id="animspeedt">--</div>
@@ -248,7 +248,7 @@ const char PAGE_index[] PROGMEM = R"=====(
                 </div>
 
                 <div class="form-group">
-                  <label for="animbrightmin" class="form-label">Animation min brightness (%)</label>
+                  <label for="animbrightmin" class="form-label" data-i18n="lbl.anim_bright_min">Animation min brightness (%)</label>
                   <div class="range-group">
                     <input type="range" id="animbrightmin" name="animbrightmin" class="range-input" min="0" max="100" step="1" oninput="updateanimbrightmin()">
                     <div class="range-value" id="animbrightmint">--</div>
@@ -256,14 +256,14 @@ const char PAGE_index[] PROGMEM = R"=====(
                 </div>
 
                 <div class="form-group">
-                  <label for="animbrightmax" class="form-label">Animation max brightness (%)</label>
+                  <label for="animbrightmax" class="form-label" data-i18n="lbl.anim_bright_max">Animation max brightness (%)</label>
                   <div class="range-group">
                     <input type="range" id="animbrightmax" name="animbrightmax" class="range-input" min="0" max="100" step="1" oninput="updateanimbrightmax()">
                     <div class="range-value" id="animbrightmaxt">--</div>
                   </div>
                 </div>
 
-                <button type="submit" class="btn btn-primary btn-block">Save Configuration</button>
+                <button type="submit" class="btn btn-primary btn-block" data-i18n="btn.save">Save Configuration</button>
               </form>
             </div>
           </div>
@@ -273,71 +273,71 @@ const char PAGE_index[] PROGMEM = R"=====(
         <section id="network-section" class="content-section">
           <div class="dashboard-grid">
             <div class="card compact-status">
-              <div class="card-title">Connection Status</div>
+              <div class="card-title" data-i18n="card.connection_status">Connection Status</div>
               <div class="status-item">
-                <div class="status-label">Current Status</div>
+                <div class="status-label" data-i18n="lbl.current_status">Current Status</div>
                 <div class="status-value" id="connectionstatedisplay">Checking...</div>
                 <div id="connectionstate" style="display: none;">Checking...</div>
               </div>
             </div>
 
             <div class="card">
-              <div class="card-title">WiFi Settings</div>
+              <div class="card-title" data-i18n="card.wifi_settings">WiFi Settings</div>
               <form id="network-form" onsubmit="return saveNetworkSettings(event)">
             <div class="form-group">
-              <label for="ssid" class="form-label">Network name (SSID)</label>
+              <label for="ssid" class="form-label" data-i18n="lbl.ssid">Network name (SSID)</label>
               <input type="text" id="ssid" name="ssid" class="form-control" placeholder="Enter network name">
             </div>
 
             <div class="form-group">
-              <label for="password" class="form-label">Password</label>
+              <label for="password" class="form-label" data-i18n="lbl.password">Password</label>
               <input type="password" id="password" name="password" class="form-control" placeholder="Enter network password">
             </div>
 
             <div class="form-group">
-              <label for="devicename" class="form-label">Device name</label>
+              <label for="devicename" class="form-label" data-i18n="lbl.device_name">Device name</label>
               <input type="text" id="devicename" name="devicename" class="form-control" placeholder="TexTime">
             </div>
 
             <div class="form-group">
               <div class="checkbox-group">
                 <input type="checkbox" id="dhcp" name="dhcp" class="checkbox" onchange="validateNetworkSettings()">
-                <label for="dhcp" class="form-label">Use DHCP (automatic IP configuration)</label>
+                <label for="dhcp" class="form-label" data-i18n="lbl.dhcp">Use DHCP (automatic IP configuration)</label>
               </div>
             </div>
 
             <div id="static-config">
               <div class="form-group">
-                <label class="form-label">IP Address</label>
+                <label class="form-label" data-i18n="lbl.ip_address">IP Address</label>
                 <input type="text" id="ipaddress" name="ipaddress" class="form-control" placeholder="192.168.1.100" pattern="^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$">
               </div>
 
               <div class="form-group">
-                <label class="form-label">Subnet Mask</label>
+                <label class="form-label" data-i18n="lbl.subnet_mask">Subnet Mask</label>
                 <input type="text" id="netmask" name="netmask" class="form-control" placeholder="255.255.255.0" pattern="^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$">
               </div>
 
               <div class="form-group">
-                <label class="form-label">Gateway</label>
+                <label class="form-label" data-i18n="lbl.gateway">Gateway</label>
                 <input type="text" id="gateway" name="gateway" class="form-control" placeholder="192.168.1.1" pattern="^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$">
               </div>
 
               <div class="form-group">
-                <label class="form-label">DNS Server</label>
+                <label class="form-label" data-i18n="lbl.dns_server">DNS Server</label>
                 <input type="text" id="dnsserver" name="dnsserver" class="form-control" placeholder="8.8.8.8" pattern="^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$">
               </div>
             </div>
 
-                <button type="submit" class="btn btn-primary btn-block">Save & Restart</button>
+                <button type="submit" class="btn btn-primary btn-block" data-i18n="btn.save_restart">Save & Restart</button>
               </form>
             </div>
 
             <div class="card">
-              <div class="card-title">Available Networks</div>
+              <div class="card-title" data-i18n="card.available_networks">Available Networks</div>
               <div id="networks" class="networks-list">
-                <div class="loading">Scanning for networks...</div>
+                <div class="loading" data-i18n="msg.scanning">Scanning for networks...</div>
               </div>
-              <button type="button" onclick="refreshNetworks()" class="btn btn-secondary btn-block">Refresh Networks</button>
+              <button type="button" onclick="refreshNetworks()" class="btn btn-secondary btn-block" data-i18n="btn.refresh_networks">Refresh Networks</button>
             </div>
           </div>
         </section>
@@ -346,23 +346,23 @@ const char PAGE_index[] PROGMEM = R"=====(
         <section id="ntp-section" class="content-section">
           <div class="dashboard-grid">
             <div class="card">
-              <div class="card-title">Time Synchronization Settings</div>
+              <div class="card-title" data-i18n="card.ntp_settings">Time Synchronization Settings</div>
               <form id="ntp-form" onsubmit="return saveNtpSettings(event)">
             <div class="form-group">
-              <label for="ntpserver" class="form-label">NTP Server</label>
+              <label for="ntpserver" class="form-label" data-i18n="lbl.ntp_server">NTP Server</label>
               <input type="text" id="ntpserver" name="ntpserver" class="form-control" maxlength="172" placeholder="pool.ntp.org">
             </div>
 
             <div class="form-group">
-              <label for="update" class="form-label">Update interval</label>
+              <label for="update" class="form-label" data-i18n="lbl.update_interval">Update interval</label>
               <div class="form-control-group">
                 <input type="number" id="update" name="update" class="form-control" maxlength="6" placeholder="3600" min="0">
-                <span>seconds (0 = disabled)</span>
+                <span data-i18n="lbl.seconds_disabled">seconds (0 = disabled)</span>
               </div>
             </div>
 
             <div class="form-group">
-              <label for="tz" class="form-label">Timezone</label>
+              <label for="tz" class="form-label" data-i18n="lbl.timezone">Timezone</label>
               <select id="tz" name="tz" class="form-control">
                 <option value="-120">(GMT-12:00) Baker Island</option>
                 <option value="-110">(GMT-11:00) Samoa</option>
@@ -403,11 +403,11 @@ const char PAGE_index[] PROGMEM = R"=====(
             <div class="form-group">
               <div class="checkbox-group">
                 <input type="checkbox" id="dst" name="dst" class="checkbox">
-                <label for="dst" class="form-label">Enable daylight saving time</label>
+                <label for="dst" class="form-label" data-i18n="lbl.dst">Enable daylight saving time</label>
               </div>
             </div>
 
-                <button type="submit" class="btn btn-primary btn-block">Save Configuration</button>
+                <button type="submit" class="btn btn-primary btn-block" data-i18n="btn.save">Save Configuration</button>
               </form>
             </div>
           </div>
@@ -417,58 +417,58 @@ const char PAGE_index[] PROGMEM = R"=====(
         <section id="mqtt-section" class="content-section">
           <div class="dashboard-grid">
             <div class="card compact-status">
-              <div class="card-title">Connection Status</div>
+              <div class="card-title" data-i18n="card.connection_status">Connection Status</div>
               <div class="status-item">
-                <div class="status-label">MQTT Connection</div>
+                <div class="status-label" data-i18n="lbl.mqtt_connection">MQTT Connection</div>
                 <div class="status-value" id="mqttconnectionstate">Checking...</div>
               </div>
             </div>
 
             <div class="card">
-              <div class="card-title">MQTT Broker Settings</div>
+              <div class="card-title" data-i18n="card.mqtt_settings">MQTT Broker Settings</div>
               <form id="mqtt-form" onsubmit="return saveMqttSettings(event)">
             <div class="form-group">
-              <label for="host" class="form-label">Broker host</label>
+              <label for="host" class="form-label" data-i18n="lbl.broker_host">Broker host</label>
               <input type="text" id="host" name="host" class="form-control" placeholder="mqtt.broker.com">
             </div>
 
             <div class="form-group">
-              <label for="port" class="form-label">Broker port</label>
+              <label for="port" class="form-label" data-i18n="lbl.broker_port">Broker port</label>
               <input type="number" id="port" name="port" class="form-control" placeholder="1883" min="1" max="65535">
             </div>
 
             <div class="form-group">
-              <label for="login" class="form-label">Username (optional)</label>
+              <label for="login" class="form-label" data-i18n="lbl.mqtt_user">Username (optional)</label>
               <input type="text" id="login" name="login" class="form-control" placeholder="Username">
             </div>
 
             <div class="form-group">
-              <label for="mqttpassword" class="form-label">Password (optional)</label>
+              <label for="mqttpassword" class="form-label" data-i18n="lbl.mqtt_password">Password (optional)</label>
               <input type="password" id="mqttpassword" name="password" class="form-control" placeholder="Password">
             </div>
 
             <div class="form-group">
-              <label for="interval" class="form-label">Publish interval</label>
+              <label for="interval" class="form-label" data-i18n="lbl.publish_interval">Publish interval</label>
               <div class="form-control-group">
                 <input type="number" id="interval" name="interval" class="form-control" placeholder="30" min="5">
-                <span>seconds</span>
+                <span data-i18n="lbl.seconds">seconds</span>
               </div>
             </div>
 
-                <button type="submit" class="btn btn-primary btn-block">Save Configuration</button>
+                <button type="submit" class="btn btn-primary btn-block" data-i18n="btn.save">Save Configuration</button>
               </form>
             </div>
 
             <div class="card">
-              <div class="card-title">MQTT Topics</div>
+              <div class="card-title" data-i18n="card.mqtt_topics">MQTT Topics</div>
 
               <div style="margin-bottom: 1.5rem;">
-                <h4 style="margin-bottom: 0.5rem; color: var(--text-primary);">Subscriber Topics</h4>
+                <h4 style="margin-bottom: 0.5rem; color: var(--text-primary);" data-i18n="lbl.sub_topics">Subscriber Topics</h4>
                 <div id="sublist" class="alert" style="font-size: 0.875rem; background: var(--surface); border-color: var(--border);">Loading...</div>
               </div>
 
               <div>
-                <h4 style="margin-bottom: 0.5rem; color: var(--text-primary);">Publisher Topics</h4>
+                <h4 style="margin-bottom: 0.5rem; color: var(--text-primary);" data-i18n="lbl.pub_topics">Publisher Topics</h4>
                 <div id="publist" class="alert" style="font-size: 0.875rem; background: var(--surface); border-color: var(--border);">Loading...</div>
               </div>
             </div>
@@ -479,66 +479,77 @@ const char PAGE_index[] PROGMEM = R"=====(
         <section id="scheduler-section" class="content-section">
           <div class="dashboard-grid">
             <div class="card">
-              <div class="card-title">Weekly Schedule</div>
+              <div class="card-title" data-i18n="card.weekly_schedule">Weekly Schedule</div>
               <div class="form-group">
                 <div class="checkbox-group">
                   <input type="checkbox" id="schedulerEnabled" class="checkbox" onchange="saveSchedulerEnabled()">
-                  <label for="schedulerEnabled" class="form-label">Enable scheduler (applies each half-hour, overrides general settings)</label>
+                  <label for="schedulerEnabled" class="form-label" data-i18n="lbl.scheduler_enable">Enable scheduler (applies each half-hour, overrides general settings)</label>
                 </div>
               </div>
-              <p style="font-size:0.8rem;color:var(--text-secondary);margin-bottom:0.75rem">Select a rule on the right, then click/drag cells to paint them. Click a painted cell again to erase it.</p>
-              <div id="schedGrid" class="sched-grid-wrap"><div class="loading">Loading...</div></div>
+              <p style="font-size:0.8rem;color:var(--text-secondary);margin-bottom:0.75rem" data-i18n="msg.sched_hint">Select a rule on the right, then click/drag cells to paint them. Click a painted cell again to erase it.</p>
+              <div id="schedGrid" class="sched-grid-wrap"><div class="loading" data-i18n="msg.loading">Loading...</div></div>
             </div>
             <div class="card sched-editor">
-              <div class="card-title">Rules</div>
+              <div class="card-title" data-i18n="card.rules">Rules</div>
               <div id="schedRulesList" style="margin-bottom:0.4rem"></div>
-              <button class="btn btn-secondary btn-block" onclick="schedAddRule()" style="margin-bottom:0.4rem">+ New rule</button>
+              <button class="btn btn-secondary btn-block" onclick="schedAddRule()" style="margin-bottom:0.4rem" data-i18n="btn.new_rule">+ New rule</button>
               <hr style="border:none;border-top:1px solid var(--border);margin-bottom:0.4rem">
               <div class="form-group">
-                <label class="form-label">Display mode</label>
+                <label class="form-label" data-i18n="lbl.display_mode">Display mode</label>
                 <select id="schedMode" class="form-control" onchange="schedEditorChange()"></select>
               </div>
               <div class="form-group">
-                <label class="form-label">Color</label>
-                <input type="color" id="schedColor" value="#ffffff" class="form-control" style="height:2rem;padding:0.1rem;cursor:pointer" onchange="schedEditorChange()">
+                <label class="form-label" data-i18n="lbl.color">Color</label>
+                <div style="display:flex;gap:0.75rem;align-items:center">
+                  <div id="schedColorSwatch" class="cpicker-swatch" title="Pick color" style="width:3rem;height:2.5rem;background:#ffffff;border:2px solid #ccc;border-radius:4px;cursor:pointer;flex-shrink:0"></div>
+                  <input type="hidden" id="schedColor" value="#ffffff">
+                </div>
+                <div id="schedCpickerPanel" class="cpicker-panel" style="display:none">
+                  <div id="schedSvSquare" class="cpicker-sv">
+                    <div class="cpicker-sv-white"></div>
+                    <div class="cpicker-sv-black"></div>
+                    <div id="schedSvThumb" class="cpicker-sv-thumb"></div>
+                  </div>
+                  <input type="range" id="schedHueSlider" class="cpicker-hue" min="0" max="359" value="0">
+                </div>
               </div>
               <div class="form-group">
-                <label class="form-label">Color randomization</label>
+                <label class="form-label" data-i18n="lbl.color_random">Color randomization</label>
                 <select id="schedColorRandom" class="form-control" onchange="schedEditorChange()">
-                  <option value="0">No Random</option>
-                  <option value="1">Random all</option>
-                  <option value="2">Random letter</option>
-                  <option value="3">Random word</option>
+                  <option value="0" data-i18n="opt.no_random">No Random</option>
+                  <option value="1" data-i18n="opt.random_all">Random all</option>
+                  <option value="2" data-i18n="opt.random_letter">Random letter</option>
+                  <option value="3" data-i18n="opt.random_word">Random word</option>
                 </select>
               </div>
               <div class="form-group">
-                <label class="form-label">Animation</label>
+                <label class="form-label" data-i18n="lbl.animation">Animation</label>
                 <select id="schedAnimation" class="form-control" onchange="schedEditorChange()"></select>
               </div>
               <div class="form-group">
-                <label class="form-label">Speed (1=slow, 20=fast)</label>
+                <label class="form-label" data-i18n="lbl.sched_speed">Speed (1=slow, 20=fast)</label>
                 <div class="range-group">
                   <input type="range" id="schedAnimSpeed" class="range-input" min="1" max="20" step="1" oninput="document.getElementById('schedAnimSpeedT').textContent=this.value;schedEditorChange()">
                   <div class="range-value" id="schedAnimSpeedT">10</div>
                 </div>
               </div>
               <div class="form-group">
-                <label class="form-label">Min brightness (%)</label>
+                <label class="form-label" data-i18n="lbl.sched_bright_min">Min brightness (%)</label>
                 <div class="range-group">
                   <input type="range" id="schedAnimBrightMin" class="range-input" min="0" max="100" step="1" oninput="document.getElementById('schedAnimBrightMinT').textContent=this.value;schedEditorChange()">
                   <div class="range-value" id="schedAnimBrightMinT">10</div>
                 </div>
               </div>
               <div class="form-group">
-                <label class="form-label">Max brightness (%)</label>
+                <label class="form-label" data-i18n="lbl.sched_bright_max">Max brightness (%)</label>
                 <div class="range-group">
                   <input type="range" id="schedAnimBrightMax" class="range-input" min="0" max="100" step="1" oninput="document.getElementById('schedAnimBrightMaxT').textContent=this.value;schedEditorChange()">
                   <div class="range-value" id="schedAnimBrightMaxT">100</div>
                 </div>
               </div>
               <div style="display:flex;gap:0.5rem;margin-top:0.5rem">
-                <button class="btn btn-secondary" onclick="schedRaz()" style="flex:1">RAZ</button>
-                <button class="btn btn-primary" id="schedSaveBtn" onclick="saveAllScheduler()" style="flex:2">Save</button>
+                <button class="btn btn-secondary" onclick="schedRaz()" style="flex:1" data-i18n="btn.raz">RAZ</button>
+                <button class="btn btn-primary" id="schedSaveBtn" onclick="saveAllScheduler()" style="flex:2" data-i18n="btn.save">Save</button>
               </div>
             </div>
           </div>
@@ -548,21 +559,20 @@ const char PAGE_index[] PROGMEM = R"=====(
         <section id="update-section" class="content-section">
           <div class="dashboard-grid">
             <div class="card">
-              <div class="card-title">Firmware Update</div>
-              <p style="margin-bottom: 1.5rem; color: var(--text-secondary);">Upload a new firmware file to update your TexTime device.</p>
+              <div class="card-title" data-i18n="card.firmware_update">Firmware Update</div>
+              <p style="margin-bottom: 1.5rem; color: var(--text-secondary);" data-i18n="msg.firmware_desc">Upload a new firmware file to update your TexTime device.</p>
 
               <div class="alert alert-warning" style="margin-bottom: 1.5rem;">
-                <strong>Warning:</strong> Only upload firmware files specifically designed for TexTime.
-                Uploading incorrect firmware can permanently damage your device.
+                <strong data-i18n="msg.warning_label">Warning:</strong> <span data-i18n="msg.firmware_warning">Only upload firmware files specifically designed for TexTime. Uploading incorrect firmware can permanently damage your device.</span>
               </div>
 
               <form action="/update" method="post" enctype="multipart/form-data">
                 <div class="form-group">
-                  <label for="firmware" class="form-label">Select firmware file (.bin)</label>
+                  <label for="firmware" class="form-label" data-i18n="lbl.firmware_file">Select firmware file (.bin)</label>
                   <input type="file" id="firmware" name="firmware" class="form-control" accept=".bin" required>
                 </div>
 
-                <button type="submit" class="btn btn-primary btn-block">Upload Firmware</button>
+                <button type="submit" class="btn btn-primary btn-block" data-i18n="btn.upload_firmware">Upload Firmware</button>
               </form>
             </div>
           </div>
@@ -580,7 +590,259 @@ const char PAGE_index[] PROGMEM = R"=====(
   <div class="overlay" id="overlay"></div>
 
   <script>
-    // Custom color picker — HSV square + hue slider, no native <input type="color">
+    // i18n dictionary
+    var I18N = {
+      0: {
+        'nav.info': 'Informations système',
+        'nav.general': 'Paramètres généraux',
+        'nav.network': 'Configuration réseau',
+        'nav.ntp': 'Configuration horaire',
+        'nav.mqtt': 'Configuration MQTT',
+        'nav.update': 'Mise à jour firmware',
+        'card.system_status': 'État du système',
+        'lbl.current_date': 'Date actuelle',
+        'lbl.uptime': 'Temps de fonctionnement',
+        'lbl.firmware_build': 'Version firmware',
+        'card.network_info': 'Informations réseau',
+        'lbl.wifi_network': 'Réseau WiFi',
+        'lbl.signal_strength': 'Force du signal',
+        'lbl.ip_address': 'Adresse IP',
+        'lbl.mac_address': 'Adresse MAC',
+        'card.sensors': 'Capteurs',
+        'lbl.ambient_light': 'Lumière ambiante',
+        'lbl.display_brightness': 'Luminosité affichage',
+        'lbl.temperature': 'Température',
+        'card.brightness': 'Contrôle de luminosité',
+        'lbl.auto_brightness': 'Luminosité automatique',
+        'lbl.brightness_sensitivity': 'Sensibilité luminosité',
+        'opt.very_high': 'Très haute',
+        'opt.high': 'Haute',
+        'opt.normal': 'Normale',
+        'opt.low': 'Faible',
+        'opt.very_low': 'Très faible',
+        'lbl.manual_brightness': 'Luminosité manuelle',
+        'lbl.day_brightness': 'Luminosité jour minimum',
+        'lbl.night_brightness': 'Luminosité nuit minimum',
+        'card.display_config': 'Configuration affichage',
+        'lbl.clock_type': "Type d'horloge",
+        'lbl.color': 'Couleur',
+        'lbl.color_random': 'Couleur aléatoire',
+        'opt.no_random': 'Aucun',
+        'opt.random_all': 'Tout aléatoire',
+        'opt.random_letter': 'Lettre aléatoire',
+        'opt.random_word': 'Mot aléatoire',
+        'lbl.language': 'Langue',
+        'lbl.display_mode': "Mode d'affichage",
+        'lbl.animation': 'Animation',
+        'lbl.anim_speed': 'Vitesse animation (1=lent, 20=rapide)',
+        'lbl.anim_bright_min': 'Luminosité min animation (%)',
+        'lbl.anim_bright_max': 'Luminosité max animation (%)',
+        'btn.save': 'Enregistrer',
+        'btn.save_restart': 'Enregistrer et redémarrer',
+        'btn.refresh_networks': 'Actualiser les réseaux',
+        'btn.upload_firmware': 'Téléverser le firmware',
+        'btn.saving': 'Enregistrement...',
+        'btn.saved': '✓ Enregistré',
+        'btn.error': '✗ Erreur',
+        'card.connection_status': 'État de connexion',
+        'lbl.current_status': 'État actuel',
+        'card.wifi_settings': 'Paramètres WiFi',
+        'lbl.ssid': 'Nom du réseau (SSID)',
+        'lbl.password': 'Mot de passe',
+        'lbl.device_name': 'Nom du dispositif',
+        'lbl.dhcp': 'Utiliser DHCP (configuration IP automatique)',
+        'lbl.subnet_mask': 'Masque de sous-réseau',
+        'lbl.gateway': 'Passerelle',
+        'lbl.dns_server': 'Serveur DNS',
+        'card.available_networks': 'Réseaux disponibles',
+        'msg.scanning': 'Recherche de réseaux...',
+        'card.ntp_settings': 'Paramètres de synchronisation horaire',
+        'lbl.ntp_server': 'Serveur NTP',
+        'lbl.update_interval': 'Intervalle de mise à jour',
+        'lbl.seconds_disabled': 'secondes (0 = désactivé)',
+        'lbl.timezone': 'Fuseau horaire',
+        'lbl.dst': "Activer l'heure d'été",
+        'lbl.mqtt_connection': 'Connexion MQTT',
+        'card.mqtt_settings': 'Paramètres du broker MQTT',
+        'lbl.broker_host': 'Hôte du broker',
+        'lbl.broker_port': 'Port du broker',
+        'lbl.mqtt_user': 'Identifiant (optionnel)',
+        'lbl.mqtt_password': 'Mot de passe (optionnel)',
+        'lbl.publish_interval': 'Intervalle de publication',
+        'lbl.seconds': 'secondes',
+        'card.mqtt_topics': 'Topics MQTT',
+        'lbl.sub_topics': 'Topics abonnés',
+        'lbl.pub_topics': 'Topics publiés',
+        'card.firmware_update': 'Mise à jour firmware',
+        'msg.firmware_desc': 'Téléversez un nouveau fichier firmware pour mettre à jour votre appareil TexTime.',
+        'msg.warning_label': 'Attention :',
+        'msg.firmware_warning': "Téléversez uniquement des fichiers firmware conçus pour TexTime. Un firmware incorrect peut endommager définitivement votre appareil.",
+        'lbl.firmware_file': 'Sélectionner le fichier firmware (.bin)',
+        'msg.loading': 'Chargement...',
+        'msg.no_networks': 'Aucun réseau trouvé',
+        'msg.network_restart': "Paramètres réseau enregistrés ! L'appareil redémarre...",
+        'status.connected': 'Connecté',
+        'status.connect': 'Connecter',
+        'status.scanning': 'Recherche...',
+        'status.disconnected': 'Déconnecté',
+        'status.connection_failed': 'Connexion échouée',
+        'status.no_network': 'Aucun réseau disponible',
+        'status.idle': 'Inactif',
+        'status.connecting': 'Connexion...',
+        'nav.scheduler': 'Programmateur',
+        'card.weekly_schedule': 'Programme hebdomadaire',
+        'lbl.scheduler_enable': "Activer le programmateur (s'applique chaque demi-heure, remplace les paramètres généraux)",
+        'msg.sched_hint': "Sélectionnez une règle à droite, puis cliquez/glissez pour peindre les cases. Recliquez une case pour l'effacer.",
+        'card.rules': 'Règles',
+        'btn.new_rule': '+ Nouvelle règle',
+        'lbl.sched_speed': 'Vitesse (1=lent, 20=rapide)',
+        'lbl.sched_bright_min': 'Luminosité min (%)',
+        'lbl.sched_bright_max': 'Luminosité max (%)',
+        'btn.raz': 'RAZ',
+        'msg.sched_raz_confirm': 'Effacer tous les créneaux ?',
+        'day.mon': 'Lun', 'day.tue': 'Mar', 'day.wed': 'Mer',
+        'day.thu': 'Jeu', 'day.fri': 'Ven', 'day.sat': 'Sam', 'day.sun': 'Dim'
+      },
+      1: {
+        'nav.info': 'System Information',
+        'nav.general': 'General Settings',
+        'nav.network': 'Network Configuration',
+        'nav.ntp': 'Time Configuration',
+        'nav.mqtt': 'MQTT Configuration',
+        'nav.update': 'Firmware Update',
+        'card.system_status': 'System Status',
+        'lbl.current_date': 'Current Date',
+        'lbl.uptime': 'Uptime',
+        'lbl.firmware_build': 'Firmware Build',
+        'card.network_info': 'Network Information',
+        'lbl.wifi_network': 'WiFi Network',
+        'lbl.signal_strength': 'Signal Strength',
+        'lbl.ip_address': 'IP Address',
+        'lbl.mac_address': 'MAC Address',
+        'card.sensors': 'Sensor Readings',
+        'lbl.ambient_light': 'Ambient Light',
+        'lbl.display_brightness': 'Display Brightness',
+        'lbl.temperature': 'Temperature',
+        'card.brightness': 'Brightness Control',
+        'lbl.auto_brightness': 'Automatic brightness',
+        'lbl.brightness_sensitivity': 'Brightness sensitivity',
+        'opt.very_high': 'Very high',
+        'opt.high': 'High',
+        'opt.normal': 'Normal',
+        'opt.low': 'Low',
+        'opt.very_low': 'Very low',
+        'lbl.manual_brightness': 'Manual brightness',
+        'lbl.day_brightness': 'Minimum day brightness',
+        'lbl.night_brightness': 'Minimum night brightness',
+        'card.display_config': 'Display Configuration',
+        'lbl.clock_type': 'Clock type',
+        'lbl.color': 'Color',
+        'lbl.color_random': 'Color randomization',
+        'opt.no_random': 'No Random',
+        'opt.random_all': 'Random all',
+        'opt.random_letter': 'Random letter',
+        'opt.random_word': 'Random word',
+        'lbl.language': 'Language',
+        'lbl.display_mode': 'Display mode',
+        'lbl.animation': 'Animation',
+        'lbl.anim_speed': 'Animation speed (1=slow, 20=fast)',
+        'lbl.anim_bright_min': 'Animation min brightness (%)',
+        'lbl.anim_bright_max': 'Animation max brightness (%)',
+        'btn.save': 'Save Configuration',
+        'btn.save_restart': 'Save & Restart',
+        'btn.refresh_networks': 'Refresh Networks',
+        'btn.upload_firmware': 'Upload Firmware',
+        'btn.saving': 'Saving...',
+        'btn.saved': '✓ Saved',
+        'btn.error': '✗ Error',
+        'card.connection_status': 'Connection Status',
+        'lbl.current_status': 'Current Status',
+        'card.wifi_settings': 'WiFi Settings',
+        'lbl.ssid': 'Network name (SSID)',
+        'lbl.password': 'Password',
+        'lbl.device_name': 'Device name',
+        'lbl.dhcp': 'Use DHCP (automatic IP configuration)',
+        'lbl.subnet_mask': 'Subnet Mask',
+        'lbl.gateway': 'Gateway',
+        'lbl.dns_server': 'DNS Server',
+        'card.available_networks': 'Available Networks',
+        'msg.scanning': 'Scanning for networks...',
+        'card.ntp_settings': 'Time Synchronization Settings',
+        'lbl.ntp_server': 'NTP Server',
+        'lbl.update_interval': 'Update interval',
+        'lbl.seconds_disabled': 'seconds (0 = disabled)',
+        'lbl.timezone': 'Timezone',
+        'lbl.dst': 'Enable daylight saving time',
+        'lbl.mqtt_connection': 'MQTT Connection',
+        'card.mqtt_settings': 'MQTT Broker Settings',
+        'lbl.broker_host': 'Broker host',
+        'lbl.broker_port': 'Broker port',
+        'lbl.mqtt_user': 'Username (optional)',
+        'lbl.mqtt_password': 'Password (optional)',
+        'lbl.publish_interval': 'Publish interval',
+        'lbl.seconds': 'seconds',
+        'card.mqtt_topics': 'MQTT Topics',
+        'lbl.sub_topics': 'Subscriber Topics',
+        'lbl.pub_topics': 'Publisher Topics',
+        'card.firmware_update': 'Firmware Update',
+        'msg.firmware_desc': 'Upload a new firmware file to update your TexTime device.',
+        'msg.warning_label': 'Warning:',
+        'msg.firmware_warning': 'Only upload firmware files specifically designed for TexTime. Uploading incorrect firmware can permanently damage your device.',
+        'lbl.firmware_file': 'Select firmware file (.bin)',
+        'msg.loading': 'Loading...',
+        'msg.no_networks': 'No networks found',
+        'msg.network_restart': 'Network settings saved! Device is restarting...',
+        'status.connected': 'Connected',
+        'status.connect': 'Connect',
+        'status.scanning': 'Scanning...',
+        'status.disconnected': 'Disconnected',
+        'status.connection_failed': 'Connection Failed',
+        'status.no_network': 'No Network Available',
+        'status.idle': 'Idle',
+        'status.connecting': 'Connecting...',
+        'nav.scheduler': 'Scheduler',
+        'card.weekly_schedule': 'Weekly Schedule',
+        'lbl.scheduler_enable': 'Enable scheduler (applies each half-hour, overrides general settings)',
+        'msg.sched_hint': 'Select a rule on the right, then click/drag cells to paint them. Click a painted cell again to erase it.',
+        'card.rules': 'Rules',
+        'btn.new_rule': '+ New rule',
+        'lbl.sched_speed': 'Speed (1=slow, 20=fast)',
+        'lbl.sched_bright_min': 'Min brightness (%)',
+        'lbl.sched_bright_max': 'Max brightness (%)',
+        'btn.raz': 'RAZ',
+        'msg.sched_raz_confirm': 'Clear all scheduled slots?',
+        'day.mon': 'Mon', 'day.tue': 'Tue', 'day.wed': 'Wed',
+        'day.thu': 'Thu', 'day.fri': 'Fri', 'day.sat': 'Sat', 'day.sun': 'Sun'
+      }
+    };
+
+    var currentLang = 0;
+
+    function T(key) {
+      var dict = I18N[currentLang] || I18N[0];
+      return dict[key] || key;
+    }
+
+    function applyI18n() {
+      document.querySelectorAll('[data-i18n]').forEach(function(el) {
+        el.textContent = T(el.dataset.i18n);
+      });
+      document.getElementById('sectionTitle').textContent = T('nav.' + currentSection);
+    }
+
+    function initI18n() {
+      return fetch('/admin/langvalue')
+        .then(function(r) { return r.text(); })
+        .then(function(v) {
+          currentLang = parseInt(v) || 0;
+          applyI18n();
+        })
+        .catch(function() {
+          applyI18n();
+        });
+    }
+
+    // HSV color picker (general settings)
     var _cpH=0, _cpS=1, _cpV=1, _cpInit=false;
 
     function _cpHsvToHex(h,s,v) {
@@ -673,27 +935,17 @@ const char PAGE_index[] PROGMEM = R"=====(
     }
 
     // Dashboard Management
-    let currentSection = 'info';
-    let updateIntervals = {};
-
-    // Section titles mapping
-    const sectionTitles = {
-      'info': 'System Information',
-      'general': 'General Settings',
-      'network': 'Network Configuration',
-      'ntp': 'Time Configuration',
-      'mqtt': 'MQTT Configuration',
-      'update': 'Firmware Update',
-      'scheduler': 'Display Scheduler'
-    };
+    var currentSection = 'info';
+    var updateIntervals = {};
 
     // Utility functions
     function debounce(func, wait) {
-      let timeout;
-      return function executedFunction(...args) {
-        const later = () => {
+      var timeout;
+      return function executedFunction() {
+        var args = arguments;
+        var later = function() {
           clearTimeout(timeout);
-          func(...args);
+          func.apply(this, args);
         };
         clearTimeout(timeout);
         timeout = setTimeout(later, wait);
@@ -702,22 +954,19 @@ const char PAGE_index[] PROGMEM = R"=====(
 
     // Navigation Management
     function switchSection(sectionName) {
-      // Update navigation
-      document.querySelectorAll('.nav-item').forEach(btn => {
+      document.querySelectorAll('.nav-item').forEach(function(btn) {
         btn.classList.remove('active');
       });
-      document.querySelector(`[data-section="${sectionName}"]`).classList.add('active');
+      var navBtn = document.querySelector('[data-section="' + sectionName + '"]');
+      if (navBtn) navBtn.classList.add('active');
 
-      // Update content
-      document.querySelectorAll('.content-section').forEach(section => {
+      document.querySelectorAll('.content-section').forEach(function(section) {
         section.classList.remove('active');
       });
-      document.getElementById(`${sectionName}-section`).classList.add('active');
+      document.getElementById(sectionName + '-section').classList.add('active');
 
-      // Update header title
-      document.getElementById('sectionTitle').textContent = sectionTitles[sectionName] || 'Dashboard';
+      document.getElementById('sectionTitle').textContent = T('nav.' + sectionName);
 
-      // Stop previous section updates
       if (updateIntervals[currentSection]) {
         clearInterval(updateIntervals[currentSection]);
         delete updateIntervals[currentSection];
@@ -725,34 +974,29 @@ const char PAGE_index[] PROGMEM = R"=====(
 
       currentSection = sectionName;
 
-      // Load section-specific data
       loadSectionData(sectionName);
-
-      // Close mobile menu
       closeMobileMenu();
     }
 
     // Mobile menu functions
     function toggleMobileMenu() {
-      const sidebar = document.getElementById('sidebar');
-      const overlay = document.getElementById('overlay');
-
+      var sidebar = document.getElementById('sidebar');
+      var overlay = document.getElementById('overlay');
       sidebar.classList.toggle('open');
       overlay.classList.toggle('active');
     }
 
     function closeMobileMenu() {
-      const sidebar = document.getElementById('sidebar');
-      const overlay = document.getElementById('overlay');
-
+      var sidebar = document.getElementById('sidebar');
+      var overlay = document.getElementById('overlay');
       sidebar.classList.remove('open');
       overlay.classList.remove('active');
     }
 
     // Theme toggle
     function toggleTheme() {
-      const html = document.documentElement;
-      const themeToggle = document.getElementById('themeToggle');
+      var html = document.documentElement;
+      var themeToggle = document.getElementById('themeToggle');
 
       if (html.getAttribute('data-theme') === 'dark') {
         html.setAttribute('data-theme', 'light');
@@ -765,25 +1009,24 @@ const char PAGE_index[] PROGMEM = R"=====(
       }
     }
 
-    // Load saved theme
     function loadTheme() {
-      const savedTheme = localStorage.getItem('theme') || 'light';
-      const html = document.documentElement;
-      const themeToggle = document.getElementById('themeToggle');
+      var savedTheme = localStorage.getItem('theme') || 'light';
+      var html = document.documentElement;
+      var themeToggle = document.getElementById('themeToggle');
 
       html.setAttribute('data-theme', savedTheme);
       themeToggle.textContent = savedTheme === 'dark' ? '☀️' : '🌙';
     }
 
     function showLoading(elementId) {
-      const element = document.getElementById(elementId);
+      var element = document.getElementById(elementId);
       if (element) {
-        element.innerHTML = '<div class="loading">Loading...</div>';
+        element.innerHTML = '<div class="loading">' + T('msg.loading') + '</div>';
       }
     }
 
     function hideLoading(elementId) {
-      const element = document.getElementById(elementId);
+      var element = document.getElementById(elementId);
       if (element && element.querySelector('.loading')) {
         element.innerHTML = '';
       }
@@ -792,91 +1035,75 @@ const char PAGE_index[] PROGMEM = R"=====(
     // Load data for specific section
     function loadSectionData(sectionName) {
       switch(sectionName) {
-        case 'info':
-          loadSystemInfo();
-          break;
-        case 'general':
-          loadGeneralSettings();
-          break;
-        case 'network':
-          loadNetworkSettings();
-          break;
-        case 'ntp':
-          loadNtpSettings();
-          break;
-        case 'mqtt':
-          loadMqttSettings();
-          break;
-        case 'scheduler':
-          loadSchedulerSettings();
-          break;
+        case 'info':    loadSystemInfo();     break;
+        case 'general': loadGeneralSettings(); break;
+        case 'network': loadNetworkSettings(); break;
+        case 'ntp':     loadNtpSettings();     break;
+        case 'mqtt':      loadMqttSettings();      break;
+        case 'scheduler': loadSchedulerSettings(); break;
       }
     }
 
-    // Network display improvements
+    // Network display
     function displayNetworks(networks) {
-      const networksContainer = document.getElementById('networks');
+      var networksContainer = document.getElementById('networks');
       if (!networks || networks.length === 0) {
-        networksContainer.innerHTML = '<div class="loading">No networks found</div>';
+        networksContainer.innerHTML = '<div class="loading">' + T('msg.no_networks') + '</div>';
         return;
       }
 
-      // Remove duplicates based on SSID
-      const uniqueNetworks = networks.filter((network, index, self) =>
-        index === self.findIndex(n => n.ssid === network.ssid)
-      );
+      var uniqueNetworks = networks.filter(function(network, index, self) {
+        return index === self.findIndex(function(n) { return n.ssid === network.ssid; });
+      });
 
-      const networksHTML = uniqueNetworks.map(network => {
-        const signalBars = getSignalBars(network.rssi);
-        const isConnected = network.connected || false;
-        const security = network.security || 'Open';
+      var networksHTML = uniqueNetworks.map(function(network) {
+        var signalBars = getSignalBars(network.rssi);
+        var isConnected = network.connected || false;
+        var security = network.security || 'Open';
 
-        return `
-          <div class="network-item ${isConnected ? 'connected' : ''}" onclick="selssid('${network.ssid}')">
-            <div class="network-info">
-              <div class="network-name">${network.ssid}</div>
-              <div class="network-details">
-                <div class="network-signal">
-                  <div class="signal-bars">${signalBars}</div>
-                  <span>${network.rssi}%</span>
-                </div>
-                <div class="network-security">
-                  <span class="security-icon">${security === 'Open' ? '🔓' : '🔒'}</span>
-                  <span>${security}</span>
-                </div>
-              </div>
-            </div>
-            <div class="network-actions">
-              ${isConnected ?
-                '<span class="connected-badge">Connected</span>' :
-                '<button class="connect-btn" onclick="event.stopPropagation(); selssid(\'${network.ssid}\')">Connect</button>'
-              }
-            </div>
-          </div>
-        `;
+        return '<div class="network-item ' + (isConnected ? 'connected' : '') + '" onclick="selssid(\'' + network.ssid + '\')">' +
+          '<div class="network-info">' +
+            '<div class="network-name">' + network.ssid + '</div>' +
+            '<div class="network-details">' +
+              '<div class="network-signal">' +
+                '<div class="signal-bars">' + signalBars + '</div>' +
+                '<span>' + network.rssi + '%</span>' +
+              '</div>' +
+              '<div class="network-security">' +
+                '<span class="security-icon">' + (security === 'Open' ? '🔓' : '🔒') + '</span>' +
+                '<span>' + security + '</span>' +
+              '</div>' +
+            '</div>' +
+          '</div>' +
+          '<div class="network-actions">' +
+            (isConnected ?
+              '<span class="connected-badge">' + T('status.connected') + '</span>' :
+              '<button class="connect-btn" onclick="event.stopPropagation(); selssid(\'' + network.ssid + '\')">' + T('status.connect') + '</button>'
+            ) +
+          '</div>' +
+        '</div>';
       }).join('');
 
       networksContainer.innerHTML = networksHTML;
     }
 
     function getSignalBars(rssi) {
-      const strength = Math.max(0, Math.min(100, rssi));
-      const bars = Math.ceil(strength / 20);
+      var strength = Math.max(0, Math.min(100, rssi));
+      var bars = Math.ceil(strength / 20);
 
-      return Array.from({length: 5}, (_, i) =>
-        `<div class="signal-bar ${i < bars ? 'active' : ''}"></div>`
-      ).join('');
+      return Array.from({length: 5}, function(_, i) {
+        return '<div class="signal-bar ' + (i < bars ? 'active' : '') + '"></div>';
+      }).join('');
     }
 
-    // Fix dropdown duplicates
     function removeDuplicateOptions(selectElement) {
-      const options = Array.from(selectElement.options);
-      const uniqueOptions = options.filter((option, index, self) =>
-        index === self.findIndex(o => o.value === option.value)
-      );
+      var options = Array.from(selectElement.options);
+      var uniqueOptions = options.filter(function(option, index, self) {
+        return index === self.findIndex(function(o) { return o.value === option.value; });
+      });
 
       selectElement.innerHTML = '';
-      uniqueOptions.forEach(option => selectElement.appendChild(option));
+      uniqueOptions.forEach(function(option) { selectElement.appendChild(option); });
     }
 
     // System Info functions
@@ -890,31 +1117,30 @@ const char PAGE_index[] PROGMEM = R"=====(
     }
 
     // General Settings functions
-    const debouncedUpdate = debounce((param, value) => {
-      setValues(`/admin/led?${param}=${value}`);
+    var debouncedUpdate = debounce(function(param, value) {
+      setValues('/admin/led?' + param + '=' + value);
     }, 300);
 
     function updatebrightness() {
-      const value = document.getElementById("brightness").value;
+      var value = document.getElementById("brightness").value;
       document.getElementById("brightnesst").textContent = value;
       debouncedUpdate("brightness", value);
     }
 
     function updatebrightnessday() {
-      const value = document.getElementById("brightnessday").value;
+      var value = document.getElementById("brightnessday").value;
       document.getElementById("brightnessdayt").textContent = value;
       debouncedUpdate("brightnessday", value);
     }
 
     function updatebrightnessnight() {
-      const value = document.getElementById("brightnessnight").value;
+      var value = document.getElementById("brightnessnight").value;
       document.getElementById("brightnessnightt").textContent = value;
       debouncedUpdate("brightnessnight", value);
     }
 
     function updatecolor(colorValue) {
-      // Remove # if present for API call
-      const cleanColor = colorValue.replace('#', '');
+      var cleanColor = colorValue.replace('#', '');
       debouncedUpdate("color", cleanColor);
     }
 
@@ -928,8 +1154,74 @@ const char PAGE_index[] PROGMEM = R"=====(
       }
     }
 
+    // HSV color picker (scheduler)
+    var _scpH=0, _scpS=1, _scpV=1, _scpInit=false;
+
+    function _scpApply(send) {
+      var hex=_cpHsvToHex(_scpH,_scpS,_scpV);
+      var sw=document.getElementById('schedColorSwatch');
+      var ci=document.getElementById('schedColor');
+      var sq=document.getElementById('schedSvSquare');
+      var th=document.getElementById('schedSvThumb');
+      var hs=document.getElementById('schedHueSlider');
+      if(sw) sw.style.backgroundColor=hex;
+      if(ci) ci.value=hex;
+      if(sq) sq.style.backgroundColor='hsl('+Math.round(_scpH)+',100%,50%)';
+      if(th){th.style.left=(_scpS*100)+'%'; th.style.top=((1-_scpV)*100)+'%';}
+      if(hs) hs.value=_scpH;
+      if(send) schedEditorChange();
+    }
+
+    function _scpSetFromHex(hex) {
+      if(!isValidHexColor(hex)) return;
+      var hsv=_cpHexToHsv(hex);
+      _scpH=hsv.h; _scpS=hsv.s; _scpV=hsv.v;
+      _scpApply(false);
+    }
+
+    function initSchedColorPicker() {
+      if(_scpInit) return;
+      _scpInit=true;
+      var swatch=document.getElementById('schedColorSwatch');
+      var panel=document.getElementById('schedCpickerPanel');
+      var sq=document.getElementById('schedSvSquare');
+      var hs=document.getElementById('schedHueSlider');
+      if(!swatch||!panel||!sq||!hs) return;
+      var panelOpen=false;
+
+      swatch.addEventListener('click', function(e) {
+        e.stopPropagation();
+        panelOpen=!panelOpen;
+        panel.style.display=panelOpen?'block':'none';
+      });
+      document.addEventListener('click', function(e) {
+        if(panelOpen && !panel.contains(e.target) && e.target!==swatch) {
+          panelOpen=false; panel.style.display='none';
+        }
+      });
+
+      var svDrag=false;
+      function onSV(e) {
+        e.preventDefault();
+        var rect=sq.getBoundingClientRect();
+        var cx=e.touches?e.touches[0].clientX:e.clientX;
+        var cy=e.touches?e.touches[0].clientY:e.clientY;
+        _scpS=Math.max(0,Math.min(1,(cx-rect.left)/rect.width));
+        _scpV=Math.max(0,Math.min(1,1-(cy-rect.top)/rect.height));
+        _scpApply(true);
+      }
+      sq.addEventListener('mousedown',  function(e){svDrag=true; onSV(e);});
+      sq.addEventListener('touchstart', function(e){svDrag=true; onSV(e);},{passive:false});
+      document.addEventListener('mousemove',  function(e){if(svDrag) onSV(e);});
+      document.addEventListener('touchmove',  function(e){if(svDrag) onSV(e);},{passive:false});
+      document.addEventListener('mouseup',    function(){svDrag=false;});
+      document.addEventListener('touchend',   function(){svDrag=false;});
+
+      hs.addEventListener('input', function(){_scpH=parseInt(this.value); _scpApply(true);});
+    }
+
     function hexToRgb(hex) {
-      const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+      var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
       return result ? {
         r: parseInt(result[1], 16),
         g: parseInt(result[2], 16),
@@ -946,7 +1238,9 @@ const char PAGE_index[] PROGMEM = R"=====(
     }
 
     function updatelang() {
-      setValues("/admin/led?lang=" + document.getElementById("lang").value);
+      currentLang = parseInt(document.getElementById("lang").value);
+      applyI18n();
+      setValues("/admin/led?lang=" + currentLang);
     }
 
     function updatemode() {
@@ -958,25 +1252,25 @@ const char PAGE_index[] PROGMEM = R"=====(
     }
 
     function updateanimspeed() {
-      const value = document.getElementById("animspeed").value;
+      var value = document.getElementById("animspeed").value;
       document.getElementById("animspeedt").textContent = value;
       debouncedUpdate("animspeed", value);
     }
 
     function updateanimbrightmin() {
-      const value = document.getElementById("animbrightmin").value;
+      var value = document.getElementById("animbrightmin").value;
       document.getElementById("animbrightmint").textContent = value;
       debouncedUpdate("animbrightmin", value);
     }
 
     function updateanimbrightmax() {
-      const value = document.getElementById("animbrightmax").value;
+      var value = document.getElementById("animbrightmax").value;
       document.getElementById("animbrightmaxt").textContent = value;
       debouncedUpdate("animbrightmax", value);
     }
 
     function validatebrightnessauto() {
-      const isAuto = document.getElementById('brightnessauto').checked;
+      var isAuto = document.getElementById('brightnessauto').checked;
 
       document.getElementById("brightness").disabled = isAuto;
       document.getElementById("brightnessday").disabled = !isAuto;
@@ -1001,40 +1295,32 @@ const char PAGE_index[] PROGMEM = R"=====(
       }
     }
 
-    // Utility function for save button feedback
     function setSaveButtonState(button, state) {
-      if (!button) {
-        return;
-      }
+      if (!button) return;
 
-      // Store original text if not already stored
-      if (!button.dataset.originalText) {
-        button.dataset.originalText = button.textContent;
-      }
-      const originalText = button.dataset.originalText;
-
+      var i18nKey = button.dataset.i18n;
       button.disabled = true;
 
       if (state === 'saving') {
-        button.textContent = 'Saving...';
+        button.textContent = T('btn.saving');
         button.style.backgroundColor = '#ffa500';
         button.style.color = 'white';
       } else if (state === 'success') {
-        button.textContent = '✓ Saved';
+        button.textContent = T('btn.saved');
         button.style.backgroundColor = '#28a745';
         button.style.color = 'white';
-        setTimeout(() => {
-          button.textContent = originalText;
+        setTimeout(function() {
+          button.textContent = i18nKey ? T(i18nKey) : T('btn.save');
           button.style.backgroundColor = '';
           button.style.color = '';
           button.disabled = false;
         }, 3000);
       } else if (state === 'error') {
-        button.textContent = '✗ Error';
+        button.textContent = T('btn.error');
         button.style.backgroundColor = '#dc3545';
         button.style.color = 'white';
-        setTimeout(() => {
-          button.textContent = originalText;
+        setTimeout(function() {
+          button.textContent = i18nKey ? T(i18nKey) : T('btn.save');
           button.style.backgroundColor = '';
           button.style.color = '';
           button.disabled = false;
@@ -1044,9 +1330,9 @@ const char PAGE_index[] PROGMEM = R"=====(
 
     function saveGeneralSettings(event) {
       event.preventDefault();
-      const form = event.target;
-      const button = form.querySelector('button[type="submit"]') || form.querySelector('button') || event.submitter;
-      const formData = new FormData(form);
+      var form = event.target;
+      var button = form.querySelector('button[type="submit"]') || form.querySelector('button') || event.submitter;
+      var formData = new FormData(form);
 
       setSaveButtonState(button, 'saving');
 
@@ -1054,16 +1340,15 @@ const char PAGE_index[] PROGMEM = R"=====(
         method: 'POST',
         body: formData
       })
-      .then(response => {
+      .then(function(response) {
         if (response.ok) {
           setSaveButtonState(button, 'success');
-          // Reload values to reflect changes
           loadGeneralSettings();
         } else {
           setSaveButtonState(button, 'error');
         }
       })
-      .catch(error => {
+      .catch(function() {
         setSaveButtonState(button, 'error');
       });
 
@@ -1073,19 +1358,18 @@ const char PAGE_index[] PROGMEM = R"=====(
     // Network Settings functions
     function loadNetworkSettings() {
       setValues("/admin/networkfieldsvalues")
-        .then(() => {
+        .then(function() {
           validateNetworkSettings();
           return refreshNetworks();
         })
-        .then(() => {
-          // Initial network status update
+        .then(function() {
           updateNetworkConnectionStatus();
         });
     }
 
     function validateNetworkSettings() {
-      const isDHCP = document.getElementById('dhcp').checked;
-      const staticConfig = document.getElementById('static-config');
+      var isDHCP = document.getElementById('dhcp').checked;
+      var staticConfig = document.getElementById('static-config');
 
       if (isDHCP) {
         staticConfig.style.opacity = '0.5';
@@ -1095,57 +1379,52 @@ const char PAGE_index[] PROGMEM = R"=====(
         staticConfig.style.pointerEvents = 'auto';
       }
 
-      ['ipaddress', 'netmask', 'gateway', 'dnsserver'].forEach(id => {
-        const element = document.getElementById(id);
-        if (element) {
-          element.disabled = isDHCP;
-        }
+      ['ipaddress', 'netmask', 'gateway', 'dnsserver'].forEach(function(id) {
+        var element = document.getElementById(id);
+        if (element) element.disabled = isDHCP;
       });
     }
 
     function refreshNetworks() {
       showLoading('networks');
       return setValues("/admin/networkconnectionvalues")
-        .then(() => {
+        .then(function() {
           hideLoading('networks');
-          // Update network connection status display
           updateNetworkConnectionStatus();
         })
-        .catch(error => {
+        .catch(function(error) {
           console.error('Failed to get network state:', error);
           document.getElementById('networks').innerHTML = '<div class="alert alert-error">Failed to scan networks</div>';
         });
     }
 
     function updateNetworkConnectionStatus() {
-      const connectionStateRaw = document.getElementById('connectionstate');
-      const connectionStateDisplay = document.getElementById('connectionstatedisplay');
+      var connectionStateRaw = document.getElementById('connectionstate');
+      var connectionStateDisplay = document.getElementById('connectionstatedisplay');
 
       if (connectionStateRaw && connectionStateDisplay && connectionStateRaw.textContent) {
-        const status = connectionStateRaw.textContent.trim();
+        var status = connectionStateRaw.textContent.trim();
 
-        // Remove existing status classes from display element
         connectionStateDisplay.classList.remove('connected', 'connecting', 'disconnected');
 
-        // Add appropriate status class and update display (keeping raw data intact)
         if (status === 'CONNECTED') {
           connectionStateDisplay.classList.add('status-indicator', 'connected');
-          connectionStateDisplay.innerHTML = '✅ Connected';
+          connectionStateDisplay.innerHTML = '✅ ' + T('status.connected');
         } else if (status === 'SCAN COMPLETED' || status === 'Checking...') {
           connectionStateDisplay.classList.add('status-indicator', 'connecting');
-          connectionStateDisplay.innerHTML = '🔍 Scanning...';
+          connectionStateDisplay.innerHTML = '🔍 ' + T('status.scanning');
         } else if (status === 'DISCONNECTED' || status === 'CONNECTION LOST') {
           connectionStateDisplay.classList.add('status-indicator', 'disconnected');
-          connectionStateDisplay.innerHTML = '❌ Disconnected';
+          connectionStateDisplay.innerHTML = '❌ ' + T('status.disconnected');
         } else if (status === 'CONNECT FAILED') {
           connectionStateDisplay.classList.add('status-indicator', 'disconnected');
-          connectionStateDisplay.innerHTML = '⚠️ Connection Failed';
+          connectionStateDisplay.innerHTML = '⚠️ ' + T('status.connection_failed');
         } else if (status === 'NO SSID AVAILBLE') {
           connectionStateDisplay.classList.add('status-indicator', 'disconnected');
-          connectionStateDisplay.innerHTML = '📡 No Network Available';
+          connectionStateDisplay.innerHTML = '📡 ' + T('status.no_network');
         } else if (status === 'Idle') {
           connectionStateDisplay.classList.add('status-indicator', 'connecting');
-          connectionStateDisplay.innerHTML = '⏳ Idle';
+          connectionStateDisplay.innerHTML = '⏳ ' + T('status.idle');
         } else {
           connectionStateDisplay.classList.add('status-indicator', 'disconnected');
           connectionStateDisplay.innerHTML = '🔄 ' + status;
@@ -1155,23 +1434,23 @@ const char PAGE_index[] PROGMEM = R"=====(
 
     function loadGeneralSettings() {
       setValues("/admin/generalledconfigvalues")
-        .then(() => setValues("/admin/generallangsvalues"))
-        .then(() => setValues("/admin/generalmodesvalues"))
-        .then(() => setValues("/admin/generalanimationsvalues"))
-        .then(() => setValues("/admin/generalfieldsvalues"))
-        .then(() => {
+        .then(function() { return setValues("/admin/generallangsvalues"); })
+        .then(function() { return setValues("/admin/generalmodesvalues"); })
+        .then(function() { return setValues("/admin/generalanimationsvalues"); })
+        .then(function() { return setValues("/admin/generalfieldsvalues"); })
+        .then(function() {
           validatebrightnessauto();
-          // Remove duplicates from dropdowns
           removeDuplicateOptions(document.getElementById('ledconfig'));
           removeDuplicateOptions(document.getElementById('lang'));
           removeDuplicateOptions(document.getElementById('mode'));
           removeDuplicateOptions(document.getElementById('animation'));
-          // Sync slider display values (setValues doesn't fire oninput)
-          document.getElementById('animspeedt').textContent = document.getElementById('animspeed').value;
-          document.getElementById('animbrightmint').textContent = document.getElementById('animbrightmin').value;
-          document.getElementById('animbrightmaxt').textContent = document.getElementById('animbrightmax').value;
-          // Initialize color picker after values are loaded
           initializeColorPicker();
+          // Sync language from loaded value and re-apply translations
+          var langEl = document.getElementById('lang');
+          if (langEl && langEl.value !== '') {
+            currentLang = parseInt(langEl.value);
+            applyI18n();
+          }
         });
     }
 
@@ -1181,9 +1460,9 @@ const char PAGE_index[] PROGMEM = R"=====(
 
     function saveNetworkSettings(event) {
       event.preventDefault();
-      const form = event.target;
-      const button = form.querySelector('button[type="submit"]') || form.querySelector('button') || event.submitter;
-      const formData = new FormData(form);
+      var form = event.target;
+      var button = form.querySelector('button[type="submit"]') || form.querySelector('button') || event.submitter;
+      var formData = new FormData(form);
 
       setSaveButtonState(button, 'saving');
 
@@ -1191,18 +1470,17 @@ const char PAGE_index[] PROGMEM = R"=====(
         method: 'POST',
         body: formData
       })
-      .then(response => {
+      .then(function(response) {
         if (response.ok) {
           setSaveButtonState(button, 'success');
-          // Network settings save triggers ESP restart, so show success and warn user
-          setTimeout(() => {
-            alert('Network settings saved! Device is restarting...');
+          setTimeout(function() {
+            alert(T('msg.network_restart'));
           }, 1000);
         } else {
           setSaveButtonState(button, 'error');
         }
       })
-      .catch(error => {
+      .catch(function() {
         setSaveButtonState(button, 'error');
       });
 
@@ -1216,9 +1494,9 @@ const char PAGE_index[] PROGMEM = R"=====(
 
     function saveNtpSettings(event) {
       event.preventDefault();
-      const form = event.target;
-      const button = form.querySelector('button[type="submit"]') || form.querySelector('button') || event.submitter;
-      const formData = new FormData(form);
+      var form = event.target;
+      var button = form.querySelector('button[type="submit"]') || form.querySelector('button') || event.submitter;
+      var formData = new FormData(form);
 
       setSaveButtonState(button, 'saving');
 
@@ -1226,16 +1504,15 @@ const char PAGE_index[] PROGMEM = R"=====(
         method: 'POST',
         body: formData
       })
-      .then(response => {
+      .then(function(response) {
         if (response.ok) {
           setSaveButtonState(button, 'success');
-          // Reload values to reflect changes
           loadNtpSettings();
         } else {
           setSaveButtonState(button, 'error');
         }
       })
-      .catch(error => {
+      .catch(function() {
         setSaveButtonState(button, 'error');
       });
 
@@ -1245,7 +1522,7 @@ const char PAGE_index[] PROGMEM = R"=====(
     // MQTT Settings functions
     function loadMqttSettings() {
       setValues("/admin/mqttfieldsvalues")
-        .then(() => {
+        .then(function() {
           getMqttState();
           updateIntervals.mqtt = setInterval(getMqttState, 3000);
         });
@@ -1253,27 +1530,24 @@ const char PAGE_index[] PROGMEM = R"=====(
 
     function getMqttState() {
       setValuesHighPriority("/admin/mqttconnectionvalues")
-        .then(() => {
-          // Update MQTT connection status display with visual indicator
+        .then(function() {
           updateMqttConnectionStatus();
         });
     }
 
     function updateMqttConnectionStatus() {
-      const connectionState = document.getElementById('mqttconnectionstate');
+      var connectionState = document.getElementById('mqttconnectionstate');
       if (connectionState && connectionState.textContent) {
-        const status = connectionState.textContent.trim();
+        var status = connectionState.textContent.trim();
 
-        // Remove existing status classes
         connectionState.classList.remove('connected', 'connecting', 'disconnected');
 
-        // Add appropriate status class and update display
         if (status === 'MQTT_CONNECTED') {
           connectionState.classList.add('status-indicator', 'connected');
-          connectionState.innerHTML = '✅ Connected';
+          connectionState.innerHTML = '✅ ' + T('status.connected');
         } else if (status.includes('CONNECTING') || status === 'Checking...') {
           connectionState.classList.add('status-indicator', 'connecting');
-          connectionState.innerHTML = '🔄 Connecting...';
+          connectionState.innerHTML = '🔄 ' + T('status.connecting');
         } else {
           connectionState.classList.add('status-indicator', 'disconnected');
           connectionState.innerHTML = '❌ ' + status.replace('MQTT_', '').replace('_', ' ');
@@ -1283,9 +1557,9 @@ const char PAGE_index[] PROGMEM = R"=====(
 
     function saveMqttSettings(event) {
       event.preventDefault();
-      const form = event.target;
-      const button = form.querySelector('button[type="submit"]') || form.querySelector('button') || event.submitter;
-      const formData = new FormData(form);
+      var form = event.target;
+      var button = form.querySelector('button[type="submit"]') || form.querySelector('button') || event.submitter;
+      var formData = new FormData(form);
 
       setSaveButtonState(button, 'saving');
 
@@ -1293,16 +1567,15 @@ const char PAGE_index[] PROGMEM = R"=====(
         method: 'POST',
         body: formData
       })
-      .then(response => {
+      .then(function(response) {
         if (response.ok) {
           setSaveButtonState(button, 'success');
-          // Reload values to reflect changes
           loadMqttSettings();
         } else {
           setSaveButtonState(button, 'error');
         }
       })
-      .catch(error => {
+      .catch(function() {
         setSaveButtonState(button, 'error');
       });
 
@@ -1312,70 +1585,60 @@ const char PAGE_index[] PROGMEM = R"=====(
     // Load function
     function load(src, type, callback) {
       if (type === 'js') {
-        const script = document.createElement('script');
+        var script = document.createElement('script');
         script.src = src;
         script.type = 'text/javascript';
         script.async = false;
-        script.onload = () => callback && callback();
-        script.onerror = () => console.error(`Failed to load script: ${src}`);
+        script.onload = function() { callback && callback(); };
+        script.onerror = function() { console.error('Failed to load script: ' + src); };
         document.head.appendChild(script);
       } else if (type === 'css') {
-        const link = document.createElement('link');
+        var link = document.createElement('link');
         link.href = src;
         link.rel = 'stylesheet';
         link.type = 'text/css';
-        link.onload = () => callback && callback();
-        link.onerror = () => console.error(`Failed to load stylesheet: ${src}`);
+        link.onload = function() { callback && callback(); };
+        link.onerror = function() { console.error('Failed to load stylesheet: ' + src); };
         document.head.appendChild(link);
       }
     }
 
     // Initialize app
     window.onload = function() {
-      load("style.css?t="+Date.now(), "css", function() {
-        // Load saved theme
+      load("style.css", "css", function() {
         loadTheme();
 
-        // Setup navigation
-        document.querySelectorAll('.nav-item').forEach(btn => {
-          btn.addEventListener('click', () => {
+        document.querySelectorAll('.nav-item').forEach(function(btn) {
+          btn.addEventListener('click', function() {
             switchSection(btn.dataset.section);
           });
         });
 
-        // Setup mobile menu
-        const menuToggle = document.getElementById('menuToggle');
-        const overlay = document.getElementById('overlay');
-        const themeToggle = document.getElementById('themeToggle');
+        var menuToggle = document.getElementById('menuToggle');
+        var overlay = document.getElementById('overlay');
+        var themeToggle = document.getElementById('themeToggle');
 
         menuToggle.addEventListener('click', toggleMobileMenu);
         overlay.addEventListener('click', closeMobileMenu);
         themeToggle.addEventListener('click', toggleTheme);
 
-        // Load initial section
+        initI18n();
         loadSectionData(currentSection);
-
-        // Initialize color picker
         initializeColorPicker();
-
-        // Set initial header title
-        document.getElementById('sectionTitle').textContent = sectionTitles[currentSection] || 'Dashboard';
 
         console.log("TexTime dashboard loaded");
       });
     }
 
-    // Cleanup intervals when leaving page
-    window.addEventListener('beforeunload', () => {
-      Object.values(updateIntervals).forEach(interval => {
+    window.addEventListener('beforeunload', function() {
+      Object.values(updateIntervals).forEach(function(interval) {
         clearInterval(interval);
       });
     });
 
-    // Handle visibility change to pause/resume updates
     window.addEventListener('visibilitychange', function() {
       if (document.hidden) {
-        Object.values(updateIntervals).forEach(interval => {
+        Object.values(updateIntervals).forEach(function(interval) {
           clearInterval(interval);
         });
         updateIntervals = {};
@@ -1384,14 +1647,12 @@ const char PAGE_index[] PROGMEM = R"=====(
       }
     });
 
-    // Handle escape key to close mobile menu
     document.addEventListener('keydown', function(event) {
       if (event.key === 'Escape') {
         closeMobileMenu();
       }
     });
 
-    // Handle window resize
     window.addEventListener('resize', function() {
       if (window.innerWidth >= 1024) {
         closeMobileMenu();
@@ -1438,7 +1699,9 @@ const char PAGE_index[] PROGMEM = R"=====(
       document.getElementById('schedAnimBrightMinT').textContent=rule.animBrightMin;
       document.getElementById('schedAnimBrightMax').value=rule.animBrightMax;
       document.getElementById('schedAnimBrightMaxT').textContent=rule.animBrightMax;
-      document.getElementById('schedColor').value='#'+toHex2(rule.r)+toHex2(rule.g)+toHex2(rule.b);
+      var schex='#'+toHex2(rule.r)+toHex2(rule.g)+toHex2(rule.b);
+      document.getElementById('schedColor').value=schex;
+      _scpSetFromHex(schex);
     }
 
     function schedRenderRulesList() {
@@ -1488,7 +1751,7 @@ const char PAGE_index[] PROGMEM = R"=====(
     }
 
     function renderSchedulerGrid() {
-      var days=['Mon','Tue','Wed','Thu','Fri','Sat','Sun'];
+      var days=[T('day.mon'),T('day.tue'),T('day.wed'),T('day.thu'),T('day.fri'),T('day.sat'),T('day.sun')];
       var html='<table class="sched-table"><thead><tr><th></th>';
       days.forEach(function(d){html+='<th>'+d+'</th>';});
       html+='</tr></thead><tbody>';
@@ -1570,12 +1833,13 @@ const char PAGE_index[] PROGMEM = R"=====(
     }
 
     function schedRaz() {
-      if(!confirm('Clear all scheduled slots?')) return;
+      if(!confirm(T('msg.sched_raz_confirm'))) return;
       schedCells=new Array(336).fill(null);
       renderSchedulerGrid();
     }
 
     function loadSchedulerSettings() {
+      initSchedColorPicker();
       setValues('/admin/schedulerconfig')
         .then(function(){
           return fetch('/admin/generalmodesvalues').then(function(r){return r.text();}).then(function(txt){
@@ -1634,27 +1898,26 @@ const char PAGE_index[] PROGMEM = R"=====(
       fetch('/admin/save/schedulerenabled',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:'enabled='+en});
     }
 
-    async function saveAllScheduler() {
+    function saveAllScheduler() {
       var btn=document.getElementById('schedSaveBtn');
       setSaveButtonState(btn,'saving');
-      try {
-        var hex='';
-        for(var i=0;i<336;i++){
-          var ri=schedCells[i];
-          if(ri===null||ri===undefined){
-            hex+='FFFFFFFFFFFFFFFF';
-          } else {
-            var rule=schedRules[ri];
-            var packed=(rule.colorRandom&0x03)|((rule.animSpeed-1)<<2);
-            hex+=toHex2(rule.mode)+toHex2(rule.anim)+toHex2(packed)
-                +toHex2(rule.animBrightMin)+toHex2(rule.animBrightMax)
-                +toHex2(rule.r)+toHex2(rule.g)+toHex2(rule.b);
-          }
+      var hex='';
+      for(var i=0;i<336;i++){
+        var ri=schedCells[i];
+        if(ri===null||ri===undefined){
+          hex+='FFFFFFFFFFFFFFFF';
+        } else {
+          var rule=schedRules[ri];
+          var packed=(rule.colorRandom&0x03)|((rule.animSpeed-1)<<2);
+          hex+=toHex2(rule.mode)+toHex2(rule.anim)+toHex2(packed)
+              +toHex2(rule.animBrightMin)+toHex2(rule.animBrightMax)
+              +toHex2(rule.r)+toHex2(rule.g)+toHex2(rule.b);
         }
-        await fetch('/admin/save/schedulerbulk',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:'data='+hex});
-        await fetch('/admin/scheduler/apply',{method:'POST'});
-        setSaveButtonState(btn,'success');
-      } catch(e){setSaveButtonState(btn,'error');}
+      }
+      fetch('/admin/save/schedulerbulk',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:'data='+hex})
+        .then(function(){return fetch('/admin/scheduler/apply',{method:'POST'});})
+        .then(function(){setSaveButtonState(btn,'success');})
+        .catch(function(){setSaveButtonState(btn,'error');});
     }
     // ── End Scheduler ──────────────────────────────────────────────────────────
 

--- a/Page_index.h
+++ b/Page_index.h
@@ -191,10 +191,19 @@ const char PAGE_index[] PROGMEM = R"=====(
               </div>
 
             <div class="form-group">
-              <label for="color" class="form-label">Color</label>
-              <div class="color-picker-container">
-                <input type="color" id="color" name="color" class="color-picker-input">
+              <label class="form-label">Color</label>
+              <div style="display:flex;gap:0.75rem;align-items:center">
+                <div id="colorSwatch" class="cpicker-swatch" title="Pick color" style="width:3rem;height:2.5rem;background:#ff0000;border:2px solid #ccc;border-radius:4px;cursor:pointer;flex-shrink:0"></div>
                 <input type="text" id="colorText" class="color-text-input" placeholder="#FF0000" maxlength="7">
+                <input type="hidden" id="color" name="color">
+              </div>
+              <div id="cpickerPanel" class="cpicker-panel" style="display:none">
+                <div id="svSquare" class="cpicker-sv">
+                  <div class="cpicker-sv-white"></div>
+                  <div class="cpicker-sv-black"></div>
+                  <div id="svThumb" class="cpicker-sv-thumb"></div>
+                </div>
+                <input type="range" id="hueSlider" class="cpicker-hue" min="0" max="359" value="0">
               </div>
             </div>
 
@@ -498,43 +507,96 @@ const char PAGE_index[] PROGMEM = R"=====(
   <div class="overlay" id="overlay"></div>
 
   <script>
-    // Initialize color picker
+    // Custom color picker — HSV square + hue slider, no native <input type="color">
+    var _cpH=0, _cpS=1, _cpV=1, _cpInit=false;
+
+    function _cpHsvToHex(h,s,v) {
+      var i=Math.floor(h/60)%6, f=h/60-Math.floor(h/60);
+      var p=v*(1-s), q=v*(1-f*s), t=v*(1-(1-f)*s);
+      var rgb=[[v,t,p],[q,v,p],[p,v,t],[p,q,v],[t,p,v],[v,p,q]][i];
+      return '#'+rgb.map(function(x){return Math.round(x*255).toString(16).padStart(2,'0');}).join('');
+    }
+
+    function _cpHexToHsv(hex) {
+      var r=parseInt(hex.slice(1,3),16)/255, g=parseInt(hex.slice(3,5),16)/255, b=parseInt(hex.slice(5,7),16)/255;
+      var max=Math.max(r,g,b), min=Math.min(r,g,b), d=max-min, h=0;
+      if(d){if(max===r)h=((g-b)/d+(g<b?6:0))*60; else if(max===g)h=((b-r)/d+2)*60; else h=((r-g)/d+4)*60;}
+      return {h:h, s:max?d/max:0, v:max};
+    }
+
+    function _cpApply(send) {
+      var hex=_cpHsvToHex(_cpH,_cpS,_cpV);
+      var sw=document.getElementById('colorSwatch');
+      var ct=document.getElementById('colorText');
+      var ci=document.getElementById('color');
+      var sq=document.getElementById('svSquare');
+      var th=document.getElementById('svThumb');
+      var hs=document.getElementById('hueSlider');
+      if(sw) sw.style.backgroundColor=hex;
+      if(ct) ct.value=hex;
+      if(ci) ci.value=hex;
+      if(sq) sq.style.backgroundColor='hsl('+Math.round(_cpH)+',100%,50%)';
+      if(th){th.style.left=(_cpS*100)+'%'; th.style.top=((1-_cpV)*100)+'%';}
+      if(hs) hs.value=_cpH;
+      if(send) updatecolor(hex);
+    }
+
+    function _cpSetFromHex(hex) {
+      if(!isValidHexColor(hex)) return;
+      var hsv=_cpHexToHsv(hex);
+      _cpH=hsv.h; _cpS=hsv.s; _cpV=hsv.v;
+      _cpApply(false);
+    }
+
     function initColorPicker() {
-      const colorInput = document.getElementById('color');
-      const colorText = document.getElementById('colorText');
-
-      if (colorInput && colorText) {
-        function syncTextToColorPicker() {
-          const currentColorValue = colorText.value;
-          if (currentColorValue) {
-            let value = currentColorValue.trim();
-            if (!value.startsWith('#')) value = '#' + value;
-            if (isValidHexColor(value)) {
-              colorInput.value = value;
-            }
-          }
-        }
-
-        // Sync color picker to text input
-        colorInput.addEventListener('input', function(e) {
-          colorText.value = e.target.value;
-          updatecolor(e.target.value);
-        });
-
-        // Sync text input to color picker
-        colorText.addEventListener('input', function(e) {
-          syncTextToColorPicker();
-          let value = e.target.value.trim();
-          if (!value.startsWith('#')) value = '#' + value;
-          if (isValidHexColor(value)) {
-            updatecolor(value);
-          }
-        });
-
-        // Sync on load
-        setTimeout(syncTextToColorPicker, 100);
-        setTimeout(syncTextToColorPicker, 500);
+      if(_cpInit) {
+        var ct=document.getElementById('colorText');
+        if(ct && ct.value) _cpSetFromHex(ct.value.trim().startsWith('#')?ct.value.trim():'#'+ct.value.trim());
+        return;
       }
+      _cpInit=true;
+      var swatch=document.getElementById('colorSwatch');
+      var panel=document.getElementById('cpickerPanel');
+      var sq=document.getElementById('svSquare');
+      var hs=document.getElementById('hueSlider');
+      var ct=document.getElementById('colorText');
+      var panelOpen=false;
+
+      swatch.addEventListener('click', function(e) {
+        e.stopPropagation();
+        panelOpen=!panelOpen;
+        panel.style.display=panelOpen?'block':'none';
+      });
+      document.addEventListener('click', function(e) {
+        if(panelOpen && !panel.contains(e.target) && e.target!==swatch) {
+          panelOpen=false; panel.style.display='none';
+        }
+      });
+
+      var svDrag=false;
+      function onSV(e) {
+        e.preventDefault();
+        var rect=sq.getBoundingClientRect();
+        var cx=e.touches?e.touches[0].clientX:e.clientX;
+        var cy=e.touches?e.touches[0].clientY:e.clientY;
+        _cpS=Math.max(0,Math.min(1,(cx-rect.left)/rect.width));
+        _cpV=Math.max(0,Math.min(1,1-(cy-rect.top)/rect.height));
+        _cpApply(true);
+      }
+      sq.addEventListener('mousedown',  function(e){svDrag=true; onSV(e);});
+      sq.addEventListener('touchstart', function(e){svDrag=true; onSV(e);},{passive:false});
+      document.addEventListener('mousemove',  function(e){if(svDrag) onSV(e);});
+      document.addEventListener('touchmove',  function(e){if(svDrag) onSV(e);},{passive:false});
+      document.addEventListener('mouseup',    function(){svDrag=false;});
+      document.addEventListener('touchend',   function(){svDrag=false;});
+
+      hs.addEventListener('input', function(){_cpH=parseInt(this.value); _cpApply(true);});
+
+      ct.addEventListener('input', function() {
+        var v=this.value.trim();
+        if(!v.startsWith('#')) v='#'+v;
+        if(isValidHexColor(v)){_cpSetFromHex(v); updatecolor(v);}
+      });
     }
 
     // Dashboard Management
@@ -781,14 +843,11 @@ const char PAGE_index[] PROGMEM = R"=====(
 
     function initializeColorPicker() {
       initColorPicker();
-      // setValues() sets colorText.value programmatically (no 'input' event fires),
-      // so we push the loaded color into colorInput here explicitly.
-      const colorInput = document.getElementById('color');
-      const colorText  = document.getElementById('colorText');
-      if (colorInput && colorText && colorText.value) {
-        let v = colorText.value.trim();
-        if (!v.startsWith('#')) v = '#' + v;
-        if (isValidHexColor(v)) colorInput.value = v;
+      var ct=document.getElementById('colorText');
+      if(ct && ct.value) {
+        var v=ct.value.trim();
+        if(!v.startsWith('#')) v='#'+v;
+        _cpSetFromHex(v);
       }
     }
 
@@ -1192,7 +1251,7 @@ const char PAGE_index[] PROGMEM = R"=====(
 
     // Initialize app
     window.onload = function() {
-      load("style.css", "css", function() {
+      load("style.css?t="+Date.now(), "css", function() {
         // Load saved theme
         loadTheme();
 

--- a/Page_network.h
+++ b/Page_network.h
@@ -75,7 +75,8 @@ void send_network_configuration_values_html()
   String values = "";
 
   values += "ssid|" + (String)_config.ssid + "|input\n";
-  values += "password|" + (String)_config.password + "|input\n";
+  values += "password||input\n";
+  values += "appassword||input\n";
   values += "ipaddress|" + (String)_config.IP[0] + "." + (String)_config.IP[1] + "." + (String)_config.IP[2] + "." + (String)_config.IP[3] + "|input\n";
   values += "netmask|" + (String)_config.Netmask[0] + "." + (String)_config.Netmask[1] + "." + (String)_config.Netmask[2] + "." + (String)_config.Netmask[3] + "|input\n";
   values += "gateway|" + (String)_config.Gateway[0] + "." + (String)_config.Gateway[1] + "." + (String)_config.Gateway[2] + "." + (String)_config.Gateway[3] + "|input\n";

--- a/Page_scheduler.h
+++ b/Page_scheduler.h
@@ -1,0 +1,170 @@
+
+// Slot layout in EEPROM (8 bytes per slot):
+//   [0] mode (0xFF = slot disabled)
+//   [1] animation
+//   [2] (colorRandom & 0x03) | ((animSpeed-1) << 2)
+//   [3] animBrightnessMin
+//   [4] animBrightnessMax
+//   [5] R  [6] G  [7] B
+//
+// 336 slots total: 7 days × 48 half-hours (slot = hour*2 + (min>=30?1:0))
+
+inline int schedAddr(byte day, byte slot) {  // slot 0..47
+  return SCHEDULER_EEPROM_BASE + 1 + (int(day) * 48 + slot) * SCHEDULER_SLOT_SIZE;
+}
+
+void send_scheduler_config() {
+  byte en = EEPROM.read(SCHEDULER_EEPROM_BASE);
+  String out = "schedulerEnabled|" + String(en == 1 ? "checked" : "") + "|chk\n";
+  _server.send(200, "text/plain", out);
+}
+
+void send_scheduler_data() {
+  _server.setContentLength(CONTENT_LENGTH_UNKNOWN);
+  _server.send(200, "text/plain", "");
+  char buf[17];
+  for (int day = 0; day < 7; day++) {
+    for (int slot = 0; slot < 48; slot++) {
+      int addr = schedAddr(day, slot);
+      for (int k = 0; k < SCHEDULER_SLOT_SIZE; k++)
+        sprintf(buf + k * 2, "%02X", EEPROM.read(addr + k));
+      buf[16] = 0;
+      _server.sendContent(buf);
+    }
+  }
+  _server.sendContent("");
+}
+
+void save_scheduler_slot() {
+  int day = -1, hour = -1, minute = 0;
+  byte mode = 0xFF, animation = 0, colorRandom = 0, animSpeed = 10;
+  byte animBrightnessMin = 10, animBrightnessMax = 100;
+  byte r = 255, g = 255, b = 255;
+  bool slotEnabled = false;
+
+  for (uint8_t i = 0; i < _server.args(); i++) {
+    String n = _server.argName(i);
+    String v = _server.arg(i);
+    if (n == "day")            day = v.toInt();
+    else if (n == "hour")      hour = v.toInt();
+    else if (n == "minute")    minute = v.toInt();
+    else if (n == "enabled")   slotEnabled = (v == "1");
+    else if (n == "mode")      mode = constrain(v.toInt(), 0, 7);
+    else if (n == "animation") animation = constrain(v.toInt(), 0, 12);
+    else if (n == "colorrandom")   colorRandom = constrain(v.toInt(), 0, 3);
+    else if (n == "animspeed")     animSpeed = constrain(v.toInt(), 1, 20);
+    else if (n == "animbrightmin") animBrightnessMin = constrain(v.toInt(), 0, 100);
+    else if (n == "animbrightmax") animBrightnessMax = constrain(v.toInt(), 0, 100);
+    else if (n == "color") {
+      String cs = v;
+      if (cs.startsWith("#")) cs = cs.substring(1);
+      int32_t l = strtol(cs.c_str(), 0, 16);
+      r = (l >> 16) & 0xFF;
+      g = (l >> 8) & 0xFF;
+      b = l & 0xFF;
+    }
+  }
+
+  if (day < 0 || day > 6 || hour < 0 || hour > 23) {
+    _server.send(400, "text/plain", "ERROR");
+    return;
+  }
+
+  int slot = hour * 2 + (minute >= 30 ? 1 : 0);
+  int addr = schedAddr(day, slot);
+  if (!slotEnabled) {
+    EEPROM.write(addr, 0xFF);
+  } else {
+    EEPROM.write(addr,     mode);
+    EEPROM.write(addr + 1, animation);
+    EEPROM.write(addr + 2, (colorRandom & 0x03) | ((animSpeed - 1) << 2));
+    EEPROM.write(addr + 3, animBrightnessMin);
+    EEPROM.write(addr + 4, animBrightnessMax);
+    EEPROM.write(addr + 5, r);
+    EEPROM.write(addr + 6, g);
+    EEPROM.write(addr + 7, b);
+  }
+  EEPROM.commit();
+  _server.send(200, "text/plain", "OK");
+}
+
+void save_scheduler_enabled() {
+  for (uint8_t i = 0; i < _server.args(); i++) {
+    if (_server.argName(i) == "enabled") {
+      EEPROM.write(SCHEDULER_EEPROM_BASE, _server.arg(i) == "1" ? 1 : 0);
+      EEPROM.commit();
+    }
+  }
+  _server.send(200, "text/plain", "OK");
+}
+
+void save_scheduler_raz() {
+  for (int i = 0; i < 336; i++)
+    EEPROM.write(SCHEDULER_EEPROM_BASE + 1 + i * SCHEDULER_SLOT_SIZE, 0xFF);
+  EEPROM.commit();
+  _server.send(200, "text/plain", "OK");
+}
+
+// Bulk save: body arg "data" = 336*16 hex chars representing all slots
+void save_scheduler_bulk() {
+  String data = _server.arg("data");
+  if (data.length() != 336 * 16) {
+    _server.send(400, "text/plain", "ERROR");
+    return;
+  }
+  char buf[3]; buf[2] = 0;
+  for (int i = 0; i < 336; i++) {
+    int addr = SCHEDULER_EEPROM_BASE + 1 + i * SCHEDULER_SLOT_SIZE;
+    for (int k = 0; k < SCHEDULER_SLOT_SIZE; k++) {
+      buf[0] = data[i * 16 + k * 2];
+      buf[1] = data[i * 16 + k * 2 + 1];
+      EEPROM.write(addr + k, (byte)strtol(buf, 0, 16));
+    }
+  }
+  EEPROM.commit();
+  _server.send(200, "text/plain", "OK");
+}
+
+byte _schedLastSlot = 255;
+byte _schedLastDay  = 255;
+
+void apply_scheduler_now() {
+  _schedLastSlot = 255;
+  _server.send(200, "text/plain", "OK");
+}
+
+// Called from loop() every iteration — runs at most once per half-hour (or immediately after apply_scheduler_now)
+void handleScheduler() {
+  if (EEPROM.read(SCHEDULER_EEPROM_BASE) != 1) return;
+
+  byte currentSlot = _dateTime.hour * 2 + (_dateTime.minute >= 30 ? 1 : 0);
+  // _dateTime.wday: 1=Sunday..7=Saturday → convert to 0=Mon..6=Sun
+  byte currentDay = (_dateTime.wday <= 1) ? 6 : (_dateTime.wday - 2);
+
+  if (currentSlot == _schedLastSlot && currentDay == _schedLastDay) return;
+  _schedLastSlot = currentSlot;
+  _schedLastDay  = currentDay;
+
+  int addr = schedAddr(currentDay, currentSlot);
+  byte mode = EEPROM.read(addr);
+  if (mode == 0xFF || mode > 7) return;
+
+  byte animation      = constrain(EEPROM.read(addr + 1), 0, 12);
+  byte packed         = EEPROM.read(addr + 2);
+  byte colorRandom    = packed & 0x03;
+  byte animSpeed      = constrain(((packed >> 2) & 0x1F) + 1, 1, 20);
+  byte animBrightMin  = constrain(EEPROM.read(addr + 3), 0, 100);
+  byte animBrightMax  = constrain(EEPROM.read(addr + 4), 0, 100);
+  byte cr = EEPROM.read(addr + 5);
+  byte cg = EEPROM.read(addr + 6);
+  byte cb = EEPROM.read(addr + 7);
+
+  _config.animBrightnessMin = animBrightMin;
+  _config.animBrightnessMax = animBrightMax;
+
+  QTLed.setMode(mode);
+  QTLed.setAnimation(animation);
+  QTLed.setColor(cr, cg, cb);
+  QTLed.setColorRandom((RandomColorMode)colorRandom);
+  QTLed.setAnimSpeed(animSpeed);
+}

--- a/Page_snake.h
+++ b/Page_snake.h
@@ -1,0 +1,150 @@
+const char PAGE_snake[] PROGMEM = R"=====(
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<style>
+*{box-sizing:border-box;-webkit-tap-highlight-color:transparent;}
+html,body{margin:0;padding:0;width:100%;height:100%;background:#111;color:#eee;font-family:sans-serif;overflow:hidden;}
+#wrap{display:flex;flex-direction:column;height:100%;padding:6px;gap:6px;}
+#topbar{display:flex;align-items:center;gap:6px;flex-shrink:0;}
+#score{flex:1;font-size:13px;text-align:right;color:#aaa;}
+#status{font-size:12px;color:#fa0;text-align:center;flex-shrink:0;}
+#gamearea{display:flex;flex:1;align-items:center;justify-content:center;min-height:0;}
+.btn{background:#222;color:#fff;border:2px solid #444;border-radius:10px;
+  cursor:pointer;touch-action:manipulation;user-select:none;-webkit-user-select:none;
+  display:flex;align-items:center;justify-content:center;}
+.btn:active{background:#444;}
+.tbtn{height:40px;padding:0 10px;font-size:13px;}
+.start{border-color:#2a5;background:#163;}
+.exit{border-color:#844;background:#422;}
+.btn svg{display:block;margin:auto;}
+.dpad{display:grid;grid-template-columns:repeat(3,90px);grid-template-rows:repeat(3,90px);gap:8px;}
+.dpad-btn{border-color:#555;}
+</style>
+<div id="wrap">
+  <div id="topbar">
+    <div class="btn tbtn start" ontouchstart="doStart(event)" onmousedown="doStart(event)">Start</div>
+    <div class="btn tbtn exit"  ontouchstart="doExit(event)"  onmousedown="doExit(event)">Exit</div>
+    <div id="status">READY</div>
+    <div id="score">Score: <b id="sc">0</b></div>
+  </div>
+  <div id="gamearea">
+    <div class="dpad">
+      <div></div>
+      <div class="btn dpad-btn" ontouchstart="aT('up',event)"    onmousedown="aMD('up')"   ><svg width="50" height="50" viewBox="0 0 24 24"><polygon points="2,22 22,22 12,2"  fill="white"/></svg></div>
+      <div></div>
+      <div class="btn dpad-btn" ontouchstart="aT('left',event)"  onmousedown="aMD('left')" ><svg width="50" height="50" viewBox="0 0 24 24"><polygon points="22,2 22,22 2,12"  fill="white"/></svg></div>
+      <div></div>
+      <div class="btn dpad-btn" ontouchstart="aT('right',event)" onmousedown="aMD('right')"><svg width="50" height="50" viewBox="0 0 24 24"><polygon points="2,2 2,22 22,12"   fill="white"/></svg></div>
+      <div></div>
+      <div class="btn dpad-btn" ontouchstart="aT('down',event)"  onmousedown="aMD('down')" ><svg width="50" height="50" viewBox="0 0 24 24"><polygon points="2,2 22,2 12,22"   fill="white"/></svg></div>
+      <div></div>
+    </div>
+  </div>
+</div>
+<script>
+function req(u){var x=new XMLHttpRequest();x.open('GET',u,true);x.send();return x;}
+function aT(a,e){e.preventDefault();req('/admin/snake?action='+a);}
+function aMD(a){req('/admin/snake?action='+a);}
+function doStart(e){e.preventDefault();req('/admin/snake?action=start');}
+function doExit(e){e.preventDefault();req('/admin/snake?action=exit');setTimeout(function(){window.location='/';},200);}
+function getState(){
+  var x=new XMLHttpRequest();
+  x.onreadystatechange=function(){
+    if(x.readyState!=4||x.status!=200)return;
+    x.responseText.split('\n').forEach(function(l){
+      var p=l.split('|');if(p.length<2)return;
+      if(p[0]=='sc'){var e=document.getElementById('sc');if(e)e.innerHTML=p[1];}
+      else if(p[0]=='status'){document.getElementById('status').innerHTML=p[1];}
+    });
+  };
+  x.open('GET','/admin/snakestate',true);x.send();
+}
+window.onload=function(){
+  load('style.css','css',function(){
+    req('/admin/snake?action=start');
+    setInterval(getState,400);
+  });
+};
+function load(e,t,n){if('css'==t){var a=document.createElement('link');a.href=e;a.rel='stylesheet';a.type='text/css';a.async=!1;a.onload=function(){n()};document.getElementsByTagName('head')[0].appendChild(a)}}
+document.addEventListener('keydown',function(e){
+  var m={'ArrowUp':'up','ArrowDown':'down','ArrowLeft':'left','ArrowRight':'right'};
+  if(m[e.key]){e.preventDefault();req('/admin/snake?action='+m[e.key]);}
+});
+var _gp={};
+function pollGP(){
+  var gs=navigator.getGamepads?navigator.getGamepads():[];
+  for(var i=0;i<gs.length;i++){
+    var g=gs[i];if(!g)continue;
+    [{b:12,a:'up'},{b:13,a:'down'},{b:14,a:'left'},{b:15,a:'right'}].forEach(function(m){
+      var p=g.buttons[m.b]&&g.buttons[m.b].pressed,k=i+'b'+m.b;
+      if(p&&!_gp[k])req('/admin/snake?action='+m.a);_gp[k]=p;
+    });
+    var ax=g.axes[0]||0,ay=g.axes[1]||0;
+    var h=ax<-0.5?'left':ax>0.5?'right':'',v=ay<-0.5?'up':ay>0.5?'down':'';
+    if(h&&_gp['h'+i]!==h)req('/admin/snake?action='+h);
+    if(v&&_gp['v'+i]!==v)req('/admin/snake?action='+v);
+    _gp['h'+i]=h;_gp['v'+i]=v;
+  }
+  requestAnimationFrame(pollGP);
+}
+window.addEventListener('gamepadconnected',function(){pollGP();});
+</script>
+)=====";
+
+void send_snake_html()
+{
+  _server.sendHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+  _server.sendHeader("Pragma", "no-cache");
+  _server.sendHeader("Expires", "-1");
+  _server.send_P(200, "text/html", PAGE_snake);
+}
+
+void send_snake_action()
+{
+  String a = _server.arg("action");
+
+  if (a == "exit") {
+    QTLed.snakeStop();
+    _server.send(200, "text/plain", "exit");
+    return;
+  }
+
+  if (a == "start") {
+    if (!QTLed.isSnakeActive()) QTLed.snakeStart();
+    else if (LedStripAnimationSnake::instance)
+      LedStripAnimationSnake::instance->action(LedStripAnimationSnake::ACT_START);
+    _server.send(200, "text/plain", "ok");
+    return;
+  }
+
+  if (LedStripAnimationSnake::instance == nullptr || !QTLed.isSnakeActive()) {
+    _server.send(200, "text/plain", "inactive");
+    return;
+  }
+
+  LedStripAnimationSnake::SnaAction act = LedStripAnimationSnake::ACT_NONE;
+  if      (a == "up")    act = LedStripAnimationSnake::ACT_UP;
+  else if (a == "down")  act = LedStripAnimationSnake::ACT_DOWN;
+  else if (a == "left")  act = LedStripAnimationSnake::ACT_LEFT;
+  else if (a == "right") act = LedStripAnimationSnake::ACT_RIGHT;
+  LedStripAnimationSnake::instance->action(act);
+  _server.send(200, "text/plain", "ok");
+}
+
+void send_snake_state()
+{
+  String s = "";
+  if (LedStripAnimationSnake::instance) {
+    LedStripAnimationSnake *t = LedStripAnimationSnake::instance;
+    s += "sc|"     + String(t->getScore()) + "\n";
+    switch (t->getState()) {
+      case LedStripAnimationSnake::STATE_PLAYING:   s += "status|PLAYING\n";   break;
+      case LedStripAnimationSnake::STATE_GAME_OVER: s += "status|GAME OVER\n"; break;
+      default:                                      s += "status|READY\n";     break;
+    }
+  }
+  _server.sendHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+  _server.sendHeader("Pragma", "no-cache");
+  _server.sendHeader("Expires", "-1");
+  _server.send(200, "text/plain", s);
+}

--- a/Page_style.css.h
+++ b/Page_style.css.h
@@ -1103,7 +1103,6 @@ body {
 .sched-half:hover { opacity: 0.75; outline: 2px solid var(--primary-color); outline-offset: -1px; }
 .sched-half + .sched-half { border-top: 1px solid rgba(128,128,128,0.25); }
 .sched-half.sched-cur { outline: 2px solid #fff; outline-offset: -2px; }
-
 /* Scheduler rules list */
 .sched-rule-item { display:flex; align-items:center; gap:0.5rem; padding:0.4rem 0.6rem; border:1px solid var(--border); border-radius:var(--radius-sm); margin-bottom:0.35rem; cursor:pointer; transition:background 0.15s; }
 .sched-rule-item:hover { background:var(--surface-hover); }
@@ -1111,5 +1110,6 @@ body {
 .sched-rule-num { min-width:1.2rem; height:1.2rem; border-radius:0.2rem; background:var(--primary-color); color:#fff; font-size:0.7rem; font-weight:700; display:flex; align-items:center; justify-content:center; flex-shrink:0; padding:0 0.2rem; }
 .sched-rule-led { width:1rem; height:1rem; border-radius:2px; border:1px solid var(--border); flex-shrink:0; }
 .sched-rule-del { background:none; border:none; cursor:pointer; color:var(--text-secondary); font-size:0.75rem; padding:0.1rem 0.3rem; border-radius:2px; line-height:1; }
+.sched-rule-del:hover { background:var(--error-color); color:#fff; }
 )=====";
 

--- a/Page_style.css.h
+++ b/Page_style.css.h
@@ -566,6 +566,46 @@ body {
   box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
 }
 
+.cpicker-swatch {
+  width:3rem; height:2.5rem;
+  border:2px solid var(--border);
+  border-radius:var(--radius-sm);
+  cursor:pointer; flex-shrink:0;
+  background:#ff0000;
+  transition:border-color 0.15s;
+}
+.cpicker-swatch:hover { border-color:var(--primary-color); }
+.cpicker-panel { margin-top:0.5rem; user-select:none; -webkit-user-select:none; }
+.cpicker-sv {
+  position:relative; width:100%; height:160px;
+  border-radius:var(--radius-sm);
+  overflow:hidden; cursor:crosshair; touch-action:none;
+}
+.cpicker-sv-white { position:absolute; inset:0; background:linear-gradient(to right,#fff,transparent); }
+.cpicker-sv-black { position:absolute; inset:0; background:linear-gradient(to bottom,transparent,#000); }
+.cpicker-sv-thumb {
+  position:absolute; width:14px; height:14px;
+  border:2px solid #fff; border-radius:50%;
+  box-shadow:0 0 3px rgba(0,0,0,.6);
+  transform:translate(-50%,-50%); pointer-events:none;
+}
+.cpicker-hue {
+  width:100%; margin-top:0.5rem; height:1.5rem;
+  -webkit-appearance:none; appearance:none;
+  background:linear-gradient(to right,#f00,#ff0,#0f0,#0ff,#00f,#f0f,#f00);
+  border-radius:var(--radius-sm); cursor:pointer; border:none; outline:none;
+}
+.cpicker-hue::-webkit-slider-thumb {
+  -webkit-appearance:none; width:18px; height:1.5rem;
+  background:rgba(255,255,255,.9); border:2px solid #888;
+  border-radius:4px; cursor:pointer;
+}
+.cpicker-hue::-moz-range-thumb {
+  width:18px; height:1.5rem;
+  background:rgba(255,255,255,.9); border:2px solid #888;
+  border-radius:4px; cursor:pointer;
+}
+
 .color-text-input {
   flex: 1;
   padding: 0.75rem;

--- a/Page_style.css.h
+++ b/Page_style.css.h
@@ -1038,5 +1038,38 @@ body {
     height: 10px;
   }
 }
+
+/* Scheduler editor card — compact overrides */
+.sched-editor { padding: 0.65rem !important; }
+.sched-editor .card-title { font-size: 0.95rem; margin-bottom: 0.35rem; }
+.sched-editor .form-group { margin-bottom: 0.3rem; }
+.sched-editor .form-label { font-size: 0.72rem; margin-bottom: 0.1rem; }
+.sched-editor .form-control { padding: 0.22rem 0.45rem; font-size: 0.78rem; }
+.sched-editor .range-group { gap: 0.3rem; }
+.sched-editor .range-input { height: 3px; }
+.sched-editor .range-value { font-size: 0.75rem; min-width: 1.8rem; }
+.sched-editor .sched-rule-item { padding: 0.25rem 0.5rem; margin-bottom: 0.2rem; }
+.sched-editor .sched-rule-num { min-width: 1rem; height: 1rem; font-size: 0.65rem; }
+.sched-editor .sched-rule-led { width: 0.85rem; height: 0.85rem; }
+.sched-editor .btn { padding: 0.28rem 0.6rem; font-size: 0.8rem; }
+
+/* Scheduler grid */
+.sched-grid-wrap { overflow-x: auto; margin-top: 0.5rem; user-select: none; -webkit-user-select: none; }
+.sched-table { border-collapse: collapse; width: 100%; font-size: 0.72rem; }
+.sched-table th { padding: 0.25rem 0.4rem; background: var(--surface); border: 1px solid var(--border); text-align: center; font-weight: 600; }
+.sched-hour { padding: 0.25rem 0.4rem; background: var(--surface); border: 1px solid var(--border); font-weight: 500; white-space: nowrap; font-size: 0.7rem; }
+.sched-cell { border: 1px solid var(--border); min-width: 2.2rem; overflow: hidden; }
+.sched-half { text-align: center; cursor: pointer; height: 0.9rem; line-height: 0.9rem; font-size: 0.6rem; overflow: hidden; transition: opacity 0.15s; }
+.sched-half:hover { opacity: 0.75; outline: 2px solid var(--primary-color); outline-offset: -1px; }
+.sched-half + .sched-half { border-top: 1px solid rgba(128,128,128,0.25); }
+.sched-half.sched-cur { outline: 2px solid #fff; outline-offset: -2px; }
+
+/* Scheduler rules list */
+.sched-rule-item { display:flex; align-items:center; gap:0.5rem; padding:0.4rem 0.6rem; border:1px solid var(--border); border-radius:var(--radius-sm); margin-bottom:0.35rem; cursor:pointer; transition:background 0.15s; }
+.sched-rule-item:hover { background:var(--surface-hover); }
+.sched-rule-active { border-color:var(--primary-color) !important; background:rgba(37,99,235,0.07); }
+.sched-rule-num { min-width:1.2rem; height:1.2rem; border-radius:0.2rem; background:var(--primary-color); color:#fff; font-size:0.7rem; font-weight:700; display:flex; align-items:center; justify-content:center; flex-shrink:0; padding:0 0.2rem; }
+.sched-rule-led { width:1rem; height:1rem; border-radius:2px; border:1px solid var(--border); flex-shrink:0; }
+.sched-rule-del { background:none; border:none; cursor:pointer; color:var(--text-secondary); font-size:0.75rem; padding:0.1rem 0.3rem; border-radius:2px; line-height:1; }
 )=====";
- 
+

--- a/Page_tetris.h
+++ b/Page_tetris.h
@@ -1,0 +1,206 @@
+const char PAGE_tetris[] PROGMEM = R"=====(
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<style>
+*{box-sizing:border-box;-webkit-tap-highlight-color:transparent;}
+html,body{margin:0;padding:0;width:100%;height:100%;background:#111;color:#eee;font-family:sans-serif;overflow:hidden;}
+#wrap{display:flex;flex-direction:column;height:100%;padding:6px;gap:6px;}
+#topbar{display:flex;align-items:center;gap:6px;flex-shrink:0;}
+#score{flex:1;font-size:13px;text-align:right;color:#aaa;}
+#status{font-size:12px;color:#fa0;text-align:center;flex-shrink:0;}
+#gamearea{display:flex;flex:1;gap:6px;min-height:0;}
+.col{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:8px;}
+.btn{background:#222;color:#fff;border:2px solid #444;border-radius:10px;
+  cursor:pointer;touch-action:manipulation;user-select:none;-webkit-user-select:none;
+  display:flex;align-items:center;justify-content:center;font-size:15px;}
+.btn:active{background:#444;}
+.tbtn{height:40px;padding:0 10px;font-size:13px;}
+.start{border-color:#2a5;background:#163;}
+.exit{border-color:#844;background:#422;}
+.dpad-row{display:flex;gap:8px;width:100%;}
+.dpad-btn{flex:1;height:110px;}
+.dpad-down{width:100%;height:72px;}
+.rotate-btn{width:140px;height:140px;border-color:#06c;}
+.btn svg{display:block;margin:auto;}
+#nextlabel{font-size:11px;color:#888;margin-bottom:2px;text-align:center;width:100%;}
+#nextcanvas{border:1px solid #333;background:#000;border-radius:6px;display:block;margin:0 auto;}
+</style>
+<div id="wrap">
+  <div id="topbar">
+    <div class="btn tbtn start" ontouchstart="doStart(event)" onmousedown="doStart(event)">Start</div>
+    <div class="btn tbtn exit"  ontouchstart="doExit(event)"  onmousedown="doExit(event)">Exit</div>
+    <div id="status">READY</div>
+    <div id="score">Score: <b id="sc">0</b> | Lines: <b id="ln">0</b> | Lv.<b id="lv">0</b></div>
+  </div>
+  <div id="gamearea">
+    <div class="col" style="flex:1.6">
+      <div class="dpad-row">
+        <div class="btn dpad-btn" ontouchstart="hT('left',event)"  ontouchend="rel(event)"  ontouchcancel="rel(event)"  onmousedown="hM('left',this)"  onmouseup="relM()" onmouseleave="relM()"><svg width="44" height="44" viewBox="0 0 24 24"><polygon points="18,3 18,21 4,12" fill="white"/></svg></div>
+        <div class="btn dpad-btn" ontouchstart="hT('right',event)" ontouchend="rel(event)"  ontouchcancel="rel(event)"  onmousedown="hM('right',this)" onmouseup="relM()" onmouseleave="relM()"><svg width="44" height="44" viewBox="0 0 24 24"><polygon points="6,3 6,21 20,12" fill="white"/></svg></div>
+      </div>
+      <div class="btn dpad-down" ontouchstart="hT('down',event)" ontouchend="rel(event)" ontouchcancel="rel(event)" onmousedown="hM('down',this)" onmouseup="relM()" onmouseleave="relM()"><svg width="44" height="44" viewBox="0 0 24 24"><polygon points="3,6 21,6 12,20" fill="white"/></svg></div>
+    </div>
+    <div class="col" style="flex:1.4">
+      <div id="nextlabel">NEXT</div>
+      <canvas id="nextcanvas" width="180" height="180"></canvas>
+    </div>
+    <div class="col" style="flex:0.8">
+      <div class="btn rotate-btn" ontouchstart="aT('rotate',event)" onmousedown="aMD('rotate')"><svg width="80" height="80" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"/><path d="M20.5 15a9 9 0 1 1-3-7.7L23 10"/></svg></div>
+    </div>
+  </div>
+</div>
+<script>
+var _ht=null;
+var SHAPES=[
+  [[1,1,1,1],[0,0,0,0],[0,0,0,0],[0,0,0,0]],
+  [[0,1,1,0],[0,1,1,0],[0,0,0,0],[0,0,0,0]],
+  [[0,1,0,0],[1,1,1,0],[0,0,0,0],[0,0,0,0]],
+  [[0,1,1,0],[1,1,0,0],[0,0,0,0],[0,0,0,0]],
+  [[1,1,0,0],[0,1,1,0],[0,0,0,0],[0,0,0,0]],
+  [[1,0,0,0],[1,1,1,0],[0,0,0,0],[0,0,0,0]],
+  [[0,0,1,0],[1,1,1,0],[0,0,0,0],[0,0,0,0]]
+];
+var COLORS=['#0CC','#CC0','#90C','#0C0','#C00','#00C','#C60'];
+function req(u){var x=new XMLHttpRequest();x.open('GET',u,true);x.send();return x;}
+function aT(a,e){e.preventDefault();req('/admin/tetris?action='+a);}
+function aMD(a){req('/admin/tetris?action='+a);}
+function hT(a,e){e.preventDefault();req('/admin/tetris?action='+a);_ht=setInterval(function(){req('/admin/tetris?action='+a);},150);}
+function hM(a,b){req('/admin/tetris?action='+a);_ht=setInterval(function(){req('/admin/tetris?action='+a);},150);}
+function rel(e){e.preventDefault();if(_ht){clearInterval(_ht);_ht=null;}}
+function relM(){if(_ht){clearInterval(_ht);_ht=null;}}
+function doStart(e){e.preventDefault();req('/admin/tetris?action=start');}
+function doExit(e){e.preventDefault();req('/admin/tetris?action=exit');setTimeout(function(){window.location='/';},200);}
+function drawNext(i){
+  var cv=document.getElementById('nextcanvas');
+  if(!cv)return;
+  var ctx=cv.getContext('2d'),sz=cv.width/4;
+  ctx.clearRect(0,0,cv.width,cv.height);
+  if(i<0||i>6)return;
+  ctx.fillStyle=COLORS[i];
+  var s=SHAPES[i];
+  var minR=4,maxR=-1,minC=4,maxC=-1;
+  for(var r=0;r<4;r++)for(var c=0;c<4;c++)
+    if(s[r][c]){if(r<minR)minR=r;if(r>maxR)maxR=r;if(c<minC)minC=c;if(c>maxC)maxC=c;}
+  var ox=(cv.width-(maxC-minC+1)*sz)/2;
+  var oy=(cv.height-(maxR-minR+1)*sz)/2;
+  for(var r=0;r<4;r++)for(var c=0;c<4;c++)
+    if(s[r][c])ctx.fillRect(ox+(c-minC)*sz+1,oy+(r-minR)*sz+1,sz-2,sz-2);
+}
+function getState(){
+  var x=new XMLHttpRequest();
+  x.onreadystatechange=function(){
+    if(x.readyState!=4||x.status!=200)return;
+    x.responseText.split('\n').forEach(function(l){
+      var p=l.split('|');if(p.length<2)return;
+      if(p[0]=='sc'||p[0]=='ln'||p[0]=='lv'){var e=document.getElementById(p[0]);if(e)e.innerHTML=p[1];}
+      else if(p[0]=='status'){document.getElementById('status').innerHTML=p[1];}
+      else if(p[0]=='next'){drawNext(parseInt(p[1]));}
+    });
+  };
+  x.open('GET','/admin/tetrisstate',true);x.send();
+}
+window.onload=function(){
+  load('style.css','css',function(){
+    req('/admin/tetris?action=start');
+    setInterval(getState,400);
+  });
+};
+function load(e,t,n){if('css'==t){var a=document.createElement('link');a.href=e;a.rel='stylesheet';a.type='text/css';a.async=!1;a.onload=function(){n()};document.getElementsByTagName('head')[0].appendChild(a)}}
+var _kr={};
+document.addEventListener('keydown',function(e){
+  if(e.repeat)return;
+  if(e.key==='ArrowLeft'){e.preventDefault();req('/admin/tetris?action=left');_kr.left=setInterval(function(){req('/admin/tetris?action=left');},150);}
+  else if(e.key==='ArrowRight'){e.preventDefault();req('/admin/tetris?action=right');_kr.right=setInterval(function(){req('/admin/tetris?action=right');},150);}
+  else if(e.key==='ArrowDown'){e.preventDefault();req('/admin/tetris?action=down');_kr.down=setInterval(function(){req('/admin/tetris?action=down');},150);}
+  else if(e.key==='ArrowUp'||e.key===' '||e.key==='z'||e.key==='a'){e.preventDefault();req('/admin/tetris?action=rotate');}
+});
+document.addEventListener('keyup',function(e){
+  if(e.key==='ArrowLeft'&&_kr.left){clearInterval(_kr.left);_kr.left=null;}
+  if(e.key==='ArrowRight'&&_kr.right){clearInterval(_kr.right);_kr.right=null;}
+  if(e.key==='ArrowDown'&&_kr.down){clearInterval(_kr.down);_kr.down=null;}
+});
+var _gp={},_gpR={};
+function pollGP(){
+  var now=Date.now(),gs=navigator.getGamepads?navigator.getGamepads():[];
+  for(var i=0;i<gs.length;i++){
+    var g=gs[i];if(!g)continue;
+    [0,1,12].forEach(function(b){var p=g.buttons[b]&&g.buttons[b].pressed,k=i+'b'+b;if(p&&!_gp[k])req('/admin/tetris?action=rotate');_gp[k]=p;});
+    [{b:14,a:'left'},{b:15,a:'right'},{b:13,a:'down'}].forEach(function(m){
+      var p=g.buttons[m.b]&&g.buttons[m.b].pressed,k=i+'b'+m.b;
+      if(p){if(!_gp[k]){req('/admin/tetris?action='+m.a);_gpR[k]=now+200;}else if(now>=(_gpR[k]||0)){req('/admin/tetris?action='+m.a);_gpR[k]=now+150;}}
+      _gp[k]=p;
+    });
+    var ax=g.axes[0]||0,ay=g.axes[1]||0,h=ax<-0.5?'left':ax>0.5?'right':'';
+    if(h){if(!_gp['h'+i]){req('/admin/tetris?action='+h);_gpR['h'+i]=now+200;}else if(now>=(_gpR['h'+i]||0)){req('/admin/tetris?action='+h);_gpR['h'+i]=now+150;}}
+    _gp['h'+i]=h;
+    var vd=ay>0.5;if(vd){if(!_gp['v'+i]){req('/admin/tetris?action=down');_gpR['v'+i]=now+200;}else if(now>=(_gpR['v'+i]||0)){req('/admin/tetris?action=down');_gpR['v'+i]=now+150;}}
+    _gp['v'+i]=vd;
+    var vu=ay<-0.5;if(vu&&!_gp['vu'+i])req('/admin/tetris?action=rotate');_gp['vu'+i]=vu;
+  }
+  requestAnimationFrame(pollGP);
+}
+window.addEventListener('gamepadconnected',function(){pollGP();});
+</script>
+)=====";
+
+void send_tetris_html()
+{
+  _server.sendHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+  _server.sendHeader("Pragma", "no-cache");
+  _server.sendHeader("Expires", "-1");
+  _server.send_P(200, "text/html", PAGE_tetris);
+}
+
+void send_tetris_action()
+{
+  String a = _server.arg("action");
+
+  if (a == "exit") {
+    QTLed.tetrisStop();
+    _server.send(200, "text/plain", "exit");
+    return;
+  }
+
+  if (a == "start") {
+    if (!QTLed.isTetrisActive()) QTLed.tetrisStart();
+    else if (LedStripAnimationTetris::instance)
+      LedStripAnimationTetris::instance->action(LedStripAnimationTetris::ACT_START);
+    _server.send(200, "text/plain", "ok");
+    return;
+  }
+
+  if (LedStripAnimationTetris::instance == nullptr || !QTLed.isTetrisActive()) {
+    _server.send(200, "text/plain", "inactive");
+    return;
+  }
+
+  LedStripAnimationTetris::TetAction act = LedStripAnimationTetris::ACT_NONE;
+  if      (a == "left")   act = LedStripAnimationTetris::ACT_LEFT;
+  else if (a == "right")  act = LedStripAnimationTetris::ACT_RIGHT;
+  else if (a == "rotate") act = LedStripAnimationTetris::ACT_ROTATE;
+  else if (a == "down")   act = LedStripAnimationTetris::ACT_DOWN;
+  else if (a == "drop")   act = LedStripAnimationTetris::ACT_DROP;
+  LedStripAnimationTetris::instance->action(act);
+  _server.send(200, "text/plain", "ok");
+}
+
+void send_tetris_state()
+{
+  String s = "";
+  if (LedStripAnimationTetris::instance) {
+    LedStripAnimationTetris *t = LedStripAnimationTetris::instance;
+    s += "sc|"     + String(t->getScore()) + "\n";
+    s += "ln|"     + String(t->getLines()) + "\n";
+    s += "lv|"     + String(t->getLevel()) + "\n";
+    s += "next|"   + String(t->getNext())  + "\n";
+    switch (t->getState()) {
+      case LedStripAnimationTetris::STATE_PLAYING:   s += "status|PLAYING\n";   break;
+      case LedStripAnimationTetris::STATE_GAME_OVER: s += "status|GAME OVER\n"; break;
+      default:                                       s += "status|READY\n";     break;
+    }
+  }
+  _server.sendHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+  _server.sendHeader("Pragma", "no-cache");
+  _server.sendHeader("Expires", "-1");
+  _server.send(200, "text/plain", s);
+}

--- a/TexTime.ino
+++ b/TexTime.ino
@@ -258,8 +258,11 @@ void setup() {
         if (_server.argName(i) == "colorrandom") _config.colorRandom = _server.arg(i).toInt();
         if (_server.argName(i) == "ledconfig") _config.ledConfig = _server.arg(i).toInt();
         if (_server.argName(i) == "brightnesssensibility") _config.luxSensitivity = _server.arg(i).toInt();
+        if (_server.argName(i) == "animspeed") _config.animSpeed = constrain(_server.arg(i).toInt(), 1, 20);
+        if (_server.argName(i) == "animbrightmin") _config.animBrightnessMin = constrain(_server.arg(i).toInt(), 0, 100);
+        if (_server.argName(i) == "animbrightmax") _config.animBrightnessMax = constrain(_server.arg(i).toInt(), 0, 100);
       }
-      
+
       WriteConfig();
       QTLed.begin();
       QTLed.setAutomaticBrightness(_config.brightnessAuto);

--- a/TexTime.ino
+++ b/TexTime.ino
@@ -45,6 +45,7 @@
 #include "Page_mqtt.h"
 #include "Page_script.js.h"
 #include "Page_style.css.h"
+#include "Page_scheduler.h"
 
 
 
@@ -71,7 +72,7 @@ void setup() {
   Serial.println("Booting");
 
   // Config load 
-  EEPROM.begin(1024); // define an EEPROM space of 1024Bytes to store data
+  EEPROM.begin(4096); // 1024 for config + 2688 for scheduler (336 slots × 8 bytes)
   CFG_saved = ReadConfig();
   if (!CFG_saved)
   {
@@ -396,6 +397,12 @@ void setup() {
     _server.send(400, "text/html", "Page not Found");
   });
 
+  _server.on("/admin/schedulerconfig", send_scheduler_config);
+  _server.on("/admin/schedulerdata", send_scheduler_data);
+  _server.on("/admin/save/schedulerbulk", HTTP_POST, save_scheduler_bulk);
+  _server.on("/admin/scheduler/apply", HTTP_POST, apply_scheduler_now);
+  _server.on("/admin/save/schedulerenabled", HTTP_POST, save_scheduler_enabled);
+
   _httpUpdater.setup(&_server);
   _server.begin();
   Serial.println("HTTP server started");
@@ -505,6 +512,7 @@ void loop() {
   mqttPollingPublisher();
 
   // Handle led display
+  handleScheduler();
   QTLed.handle();
 
   // For debug purpose only

--- a/TexTime.ino
+++ b/TexTime.ino
@@ -45,6 +45,8 @@
 #include "Page_mqtt.h"
 #include "Page_script.js.h"
 #include "Page_style.css.h"
+#include "Page_tetris.h"
+#include "Page_snake.h"
 
 
 
@@ -52,12 +54,8 @@ extern "C" {
 #include "user_interface.h"
 }
 
-IPAddress _apIP(192, 168, 1, 1);
-IPAddress _apNetMsk(255, 255, 255, 0);
-
 //*** Normal code definition here ...
 void setup() {
-  String chipID;
   bool CFG_saved = false;
 
   // No need to set this until option is set in arduino/visualmicro
@@ -71,7 +69,7 @@ void setup() {
   Serial.println("Booting");
 
   // Config load 
-  EEPROM.begin(1024); // define an EEPROM space of 1024Bytes to store data
+  EEPROM.begin(EEPROM_SIZE);
   CFG_saved = ReadConfig();
   if (!CFG_saved)
   {
@@ -96,12 +94,16 @@ void setup() {
     _config.brightness = 128; // [0:255]
     _config.brightnessAutoMinDay = 30; // [0:255]
     _config.brightnessAutoMinNight = 0; // [0:255]
+    _config.brightnessMax = 255; // [0:255]
     _config.color[0] = 255; // R
     _config.color[1] = 255; // G
     _config.color[2] = 255; // B
     _config.color[3] = 255; // W
     _config.mode = 1;
     _config.animation = 0;
+    _config.animSpeed = 10;
+    _config.animBrightnessMin = 10;
+    _config.animBrightnessMax = 100;
     _config.ledConfig = 0;
     _config.luxSensitivity = 40;
     _config.language = 0;
@@ -111,6 +113,9 @@ void setup() {
     _config.MQTTPassword = "";
     _config.MQTTPort = 1883;
     _config.MQTTPubInterval = 120; // in sec
+
+    _config.APPassword = AP_DEFAULT_PASSWORD;
+    WriteConfig();
   }
 
   // Start led strip
@@ -128,7 +133,7 @@ void setup() {
   //printConfig();
 
   // Configure WiFi
-  WiFiMgr.setAPssid("TexTime-" + String(ESP.getChipId(), HEX));
+  WiFiMgr.setAPssid("TexTime-" + String(ESP.getChipId(), HEX), _config.APPassword);
 
   if (!_config.dhcp)
   {
@@ -139,7 +144,7 @@ void setup() {
   }
 
   // Start WiFi
-  WiFiMgr.tryToConnect(_config.ssid, _config.password, &_config.DeviceName[0]);
+  WiFiMgr.tryToConnect(_config.ssid, _config.password, _config.DeviceName);
 
   // Start HTTP Server for configuration
   _server.on("/", []() {
@@ -217,7 +222,15 @@ void setup() {
   _server.on("/admin/generalledconfigvalues", send_general_ledconfig_values_html);
 
   _server.on("/admin/led", send_general_led);
-  
+
+  _server.on("/tetris.html", send_tetris_html);
+  _server.on("/admin/tetris", send_tetris_action);
+  _server.on("/admin/tetrisstate", send_tetris_state);
+
+  _server.on("/snake.html", send_snake_html);
+  _server.on("/admin/snake", send_snake_action);
+  _server.on("/admin/snakestate", send_snake_state);
+
   // Async save endpoints
   _server.on("/admin/save/general", HTTP_POST, []() {
     if (_server.args() > 0) {
@@ -268,7 +281,8 @@ void setup() {
       _config.dhcp = false;
       for (uint8_t i = 0; i < _server.args(); i++) {
         if (_server.argName(i) == "ssid") _config.ssid = _server.arg(i);
-        if (_server.argName(i) == "password") _config.password = _server.arg(i);
+        if (_server.argName(i) == "password") { String p = _server.arg(i); if (p.length() > 0) _config.password = p; }
+        if (_server.argName(i) == "appassword") { String p = _server.arg(i); if (p.length() >= 8) _config.APPassword = p; }
         if (_server.argName(i) == "ipaddress") {
           // Parse IP address string like "192.168.1.100"
           String ip = _server.arg(i);
@@ -449,7 +463,7 @@ void setup() {
   // MQTT configuration
   if (_config.MQTTPubInterval < 1) _config.MQTTPubInterval = 1;
   _mqttWifiClient.setNoDelay(true);
-  _mqttWifiClient.setTimeout(MQTT_SOCKET_TIMEOUT * 1000);
+  _mqttWifiClient.setTimeout((unsigned long)MQTT_SOCKET_TIMEOUT * 1000UL);
   _mqtt.setServer(_config.MQTTServer.c_str(), _config.MQTTPort);
   _mqtt.setCallback(mqttCallback);
 

--- a/TexTime.ino
+++ b/TexTime.ino
@@ -222,6 +222,7 @@ void setup() {
   _server.on("/admin/generalanimationsvalues", send_general_animations_values_html);
   _server.on("/admin/generalledconfigvalues", send_general_ledconfig_values_html);
 
+  _server.on("/admin/langvalue", send_lang_value_html);
   _server.on("/admin/led", send_general_led);
 
   _server.on("/tetris.html", send_tetris_html);

--- a/WiFiMgr.cpp
+++ b/WiFiMgr.cpp
@@ -9,7 +9,7 @@ WiFiMgrClass::WiFiMgrClass()
   , _STAkey("")
   , _devicename("")
   , _STAlastTry(0)
-  , _STAtryTimeout(10 * 1000)
+  , _STAtryTimeout(30 * 1000)
   , _APssid("")
   , _APkey("")
   , _APlastTry(0)
@@ -45,7 +45,7 @@ void WiFiMgrClass::setSTAIPip(IPAddress ip, IPAddress gw, IPAddress mask, IPAddr
   setSTAIPdhcp(false);
 }
 
-void WiFiMgrClass::tryToConnect(String ssid, String key, String devicename)
+void WiFiMgrClass::tryToConnect(const String& ssid, const String& key, const String& devicename)
 {
   _STAssid = ssid;
   _STAkey = key;
@@ -70,9 +70,10 @@ void WiFiMgrClass::tryToReconnect()
   wifi_station_set_hostname(_devicename.c_str()); //See more at : http ://www.esp8266.com/viewtopic.php?f=29&t=11124#sthash.458xtq2U.dpuf
 
   Serial.print("Trying to connect to ");
-  Serial.print(_STAssid.c_str());
-  Serial.print(" with key : ");
-  Serial.println(_STAkey.c_str());
+  Serial.println(_STAssid.c_str());
+
+  if (!_STADHCP)
+    WiFi.config(_STAIPip, _STAIPgw, _STAIPmask, _STAIPdns);
 
   WiFi.begin(_STAssid, _STAkey);
 
@@ -83,15 +84,16 @@ void WiFiMgrClass::tryToReconnect()
 
 void WiFiMgrClass::setAPMode()
 {
-  IPAddress apIP(192, 168, 1, 1);
+  IPAddress apIP(192, 168, 4, 1);
   IPAddress apNetMsk(255, 255, 255, 0);
 
+  WiFi.setAutoReconnect(false);
   WiFi.mode(WIFI_AP);
   WiFi.softAPConfig(apIP, apIP, apNetMsk);
 
   Serial.println("Setting AP mode");
 
-  if (_APkey.length() == 0)
+  if (_APkey.length() < 8)
     WiFi.softAP(_APssid);
   else
     WiFi.softAP(_APssid, _APkey);
@@ -111,9 +113,6 @@ bool WiFiMgrClass::handle()
       return false;
 
     Serial.println("WiFi Connected");
-
-    if (!_STADHCP)
-      WiFi.config(_STAIPip, _STAIPgw, _STAIPmask, _STAIPdns);
 
     Serial.print("WiFi IP : ");
     Serial.println(WiFi.localIP());

--- a/WiFiMgr.h
+++ b/WiFiMgr.h
@@ -19,9 +19,9 @@ public:
   void setSTAIPdhcp(bool dhcp);
   void setSTAIPip(IPAddress ip, IPAddress gw, IPAddress mask, IPAddress dns);
 
-  void setAPssid(String ssid, String key = "");
+  void setAPssid(String ssid, String key);
 
-  void tryToConnect(String ssid, String key, String devicename);
+  void tryToConnect(const String& ssid, const String& key, const String& devicename);
   bool handle();
 
 protected:
@@ -29,12 +29,12 @@ private:
   String _STAssid;
   String _STAkey;
   String _devicename;
-  unsigned int _STAlastTry;
-  unsigned int _STAtryTimeout;
+  unsigned long _STAlastTry;
+  unsigned long _STAtryTimeout;
   String _APssid;
   String _APkey;
-  unsigned int _APlastTry;
-  unsigned int _APtryTimeout;
+  unsigned long _APlastTry;
+  unsigned long _APtryTimeout;
   bool _STAconnected;
   IPAddress _STAIPip;
   IPAddress _STAIPgw;

--- a/global.h
+++ b/global.h
@@ -240,6 +240,7 @@ boolean ReadConfig(){
     _config.color[3] = EEPROM.read(389); // W
     _config.mode = EEPROM.read(390);
     _config.animation = EEPROM.read(391);
+    if (_config.animation > 12) _config.animation = 0;
     _config.colorRandom = EEPROM.read(392);
     _config.brightnessAutoMinDay = EEPROM.read(393);
     _config.brightnessAutoMinNight = EEPROM.read(394);

--- a/global.h
+++ b/global.h
@@ -44,6 +44,10 @@ struct strConfig {
 } _config;
 
 
+// Scheduler EEPROM layout: 336 slots (7 days × 48 half-hours) × 8 bytes, starting at 1024
+#define SCHEDULER_EEPROM_BASE 1024
+#define SCHEDULER_SLOT_SIZE   8
+
 //  Auxiliary function to handle EEPROM
 
 void EEPROMWritelong(int address, long value){

--- a/global.h
+++ b/global.h
@@ -2,7 +2,9 @@
 #define GLOBAL_H
 
 #define AP_DEFAULT_PASSWORD "TexTime-Setup"
-#define EEPROM_SIZE 1024
+#define EEPROM_SIZE 4096
+#define SCHEDULER_EEPROM_BASE 1024
+#define SCHEDULER_SLOT_SIZE 8
 
 ESP8266HTTPUpdateServer _httpUpdater;
 ESP8266WebServer _server(80);
@@ -53,10 +55,6 @@ struct strConfig {
 
 } _config;
 
-
-// Scheduler EEPROM layout: 336 slots (7 days × 48 half-hours) × 8 bytes, starting at 1024
-#define SCHEDULER_EEPROM_BASE 1024
-#define SCHEDULER_SLOT_SIZE   8
 
 //  Auxiliary function to handle EEPROM
 

--- a/global.h
+++ b/global.h
@@ -1,6 +1,8 @@
 #ifndef GLOBAL_H
 #define GLOBAL_H
 
+#define AP_DEFAULT_PASSWORD "TexTime-Setup"
+#define EEPROM_SIZE 1024
 
 ESP8266HTTPUpdateServer _httpUpdater;
 ESP8266WebServer _server(80);
@@ -34,12 +36,20 @@ struct strConfig {
   byte ledConfig;                       // 1 Byte - EEPROM 395
   byte luxSensitivity;                  // 1 Byte - EEPROM 396
   byte language;                        // 1 Byte - EEPROM 397
+  byte brightnessMax;                   // 1 Byte - EEPROM 398  
+
 
   String MQTTServer;                    // up to 64 Byte - EEPROM 512
   String MQTTLogin;                     // up to 64 Byte - EEPROM 576
   String MQTTPassword;                  // up to 64 Byte - EEPROM 640
   long MQTTPort;                        // 4 Byte - EEPROM 704
   long MQTTPubInterval;                 // 4 Byte - EEPROM 708
+
+  String APPassword;                    // up to 64 Byte - EEPROM 712
+
+  byte animSpeed;          // 1 Byte - EEPROM 776  (1-20, 10=normal)
+  byte animBrightnessMin;  // 1 Byte - EEPROM 777  (0-100 percent)
+  byte animBrightnessMax;  // 1 Byte - EEPROM 778  (0-100 percent)
 
 } _config;
 
@@ -72,20 +82,15 @@ long EEPROMReadlong(long address){
 
 // Check the Values is between 0-255
 boolean checkRange(String Value){
-  if (Value.toInt() < 0 || Value.toInt() > 255)
-  {
-    return false;
-  }
-  else
-  {
-    return true;
-  }
+  int v = Value.toInt();
+  return (v >= 0 && v <= 255);
 }
 
-void WriteStringToEEPROM(int beginaddress, String string){
-  char  charBuf[string.length() + 1];
-  string.toCharArray(charBuf, string.length() + 1);
-  for (unsigned int t =  0; t < sizeof(charBuf); t++)
+void WriteStringToEEPROM(int beginaddress, String string, int maxLen = 63){
+  if ((int)string.length() > maxLen) string = string.substring(0, maxLen);
+  char  charBuf[64];
+  string.toCharArray(charBuf, sizeof(charBuf));
+  for (unsigned int t = 0; t < sizeof(charBuf); t++)
   {
     EEPROM.write(beginaddress + t, charBuf[t]);
   }
@@ -101,12 +106,11 @@ String  ReadStringFromEEPROM(int beginaddress){
 
   while (1)
   {
+    if (counter >= 64) break;
     rChar = EEPROM.read(beginaddress + counter);
     if (rChar == 0) break;
-    if (counter > 63) break;
     counter++;
     retString.concat(rChar);
-
   }
   return retString;
 }
@@ -120,7 +124,7 @@ String  ReadStringFromEEPROM(int beginaddress){
 
 void ResetEEPROM()
 {
-  for (int i = 0; i < 511; i++)
+  for (int i = 0; i < EEPROM_SIZE; i++)
     EEPROM.write(i, 0xFF);
 
   EEPROM.commit();
@@ -179,12 +183,19 @@ void WriteConfig(){
   EEPROM.write(395, _config.ledConfig);
   EEPROM.write(396, _config.luxSensitivity);
   EEPROM.write(397, _config.language);
+  EEPROM.write(398, _config.brightnessMax);  
 
   WriteStringToEEPROM(512, _config.MQTTServer);
   WriteStringToEEPROM(576, _config.MQTTLogin);
   WriteStringToEEPROM(640, _config.MQTTPassword);
   EEPROMWritelong(704, _config.MQTTPort);
   EEPROMWritelong(708, _config.MQTTPubInterval);
+
+  WriteStringToEEPROM(712, _config.APPassword);
+
+  EEPROM.write(776, _config.animSpeed);
+  EEPROM.write(777, _config.animBrightnessMin);
+  EEPROM.write(778, _config.animBrightnessMax);
 
   EEPROM.commit();
 }
@@ -198,6 +209,7 @@ boolean ReadConfig(){
     _config.isDayLightSaving = EEPROM.read(17);
     _config.Update_Time_Via_NTP_Every = EEPROMReadlong(18); // 4 Byte
     _config.timeZone = EEPROMReadlong(22); // 4 Byte
+    if (_config.timeZone < -120 || _config.timeZone > 130) _config.timeZone = 10; // sanity check (unit = 1/10th hour)
     _config.IP[0] = EEPROM.read(32);
     _config.IP[1] = EEPROM.read(33);
     _config.IP[2] = EEPROM.read(34);
@@ -231,6 +243,7 @@ boolean ReadConfig(){
     _config.colorRandom = EEPROM.read(392);
     _config.brightnessAutoMinDay = EEPROM.read(393);
     _config.brightnessAutoMinNight = EEPROM.read(394);
+    _config.brightnessMax = EEPROM.read(398);
     _config.ledConfig = EEPROM.read(395);
     _config.luxSensitivity = EEPROM.read(396);
     _config.language = EEPROM.read(397);
@@ -240,6 +253,16 @@ boolean ReadConfig(){
     _config.MQTTPassword = ReadStringFromEEPROM(640);
     _config.MQTTPort = EEPROMReadlong(704);
     _config.MQTTPubInterval = EEPROMReadlong(708);
+
+    _config.APPassword = ReadStringFromEEPROM(712);
+    if (_config.APPassword.length() < 8) _config.APPassword = AP_DEFAULT_PASSWORD;
+
+    _config.animSpeed = EEPROM.read(776);
+    if (_config.animSpeed < 1 || _config.animSpeed > 20) _config.animSpeed = 10;
+    _config.animBrightnessMin = EEPROM.read(777);
+    if (_config.animBrightnessMin > 100) _config.animBrightnessMin = 10;
+    _config.animBrightnessMax = EEPROM.read(778);
+    if (_config.animBrightnessMax > 100 || _config.animBrightnessMax <= _config.animBrightnessMin) _config.animBrightnessMax = 100;
 
     return true;
 
@@ -270,7 +293,7 @@ void printConfig(){
 
  
   Serial.printf("SSID:%s\n", _config.ssid.c_str());
-  Serial.printf("PWD:%s\n", _config.password.c_str());
+  Serial.printf("PWD:***\n");
   Serial.printf("NTP ServerName:%s\n", _config.ntpServerName.c_str());
   Serial.printf("Device Name:%s\n", _config.DeviceName.c_str());
 
@@ -283,6 +306,7 @@ void printConfig(){
   Serial.printf("Color Random:%d\n", _config.colorRandom);
   Serial.printf("Minimum brightness auto during the day:%d\n", _config.brightnessAutoMinDay);
   Serial.printf("Minimum brightness auto during the night:%d\n", _config.brightnessAutoMinNight);
+  Serial.printf("Max brightness:%d\n", _config.brightnessMax);
   Serial.printf("Led Configuration:%d\n", _config.ledConfig);
 }
 


### PR DESCRIPTION
## Summary / Résumé

**EN** — Combines the weekly display scheduler (PR #7) and the full FR/EN interface translation (PR #8), plus a custom HSV color picker, animation controls, Tetris & Snake games, and various bugfixes.

**FR** — Combine le programmateur d'affichage hebdomadaire (PR #7) et la traduction complète FR/EN de l'interface (PR #8), ainsi qu'un sélecteur de couleur HSV personnalisé, des contrôles d'animation, les jeux Tetris & Snake, et divers correctifs.

---

## Weekly Display Scheduler / Programmateur d'affichage hebdomadaire

**EN** — Adds a configurable weekly scheduler that automatically switches the display mode and animation every half-hour.

**FR** — Ajoute un programmateur hebdomadaire configurable qui change automatiquement le mode d'affichage et l'animation toutes les demi-heures.

### Features / Fonctionnalités

- 7-day × 48-slot (30-min granularity) visual grid editor / Grille visuelle 7 jours × 48 créneaux (granularité 30 min)
- Per-slot rules: mode, animation, speed, brightness min/max, LED color, color randomization / Règles par créneau : mode, animation, vitesse, luminosité min/max, couleur LED, randomisation
- Color-coded grid cells (actual LED color, auto readable text) / Cellules colorées avec la vraie couleur LED (texte lisible automatiquement)
- Rule numbering in cells and rule list / Numérotation des règles dans les cellules et la liste
- Bulk EEPROM save — single POST for all 336 slots / Sauvegarde EEPROM groupée — un seul POST pour les 336 créneaux
- Rules applied automatically by `handleScheduler()` called from `loop()` / Application automatique via `handleScheduler()` appelé depuis `loop()`
- Enable/disable toggle with EEPROM persistence / Activation/désactivation avec persistance EEPROM

### New server routes / Nouvelles routes serveur

| Route | Method | Description (EN) | Description (FR) |
|-------|--------|-------------------|------------------|
| `/admin/schedulerconfig` | GET | Returns enabled flag | Retourne le flag activé/désactivé |
| `/admin/schedulerdata` | GET | Returns 336 slots as hex dump | Retourne les 336 créneaux en hex |
| `/admin/save/schedulerbulk` | POST | Bulk write all 336 slots | Écriture groupée des 336 créneaux |
| `/admin/save/schedulerenabled` | POST | Toggle enabled flag | Bascule le flag activé/désactivé |
| `/admin/scheduler/apply` | POST | Force immediate re-apply | Force l'application immédiate du créneau courant |

### EEPROM changes / Modifications EEPROM

- `EEPROM_SIZE` increased from 1024 to 4096 bytes / augmenté de 1024 à 4096 octets
- Scheduler base offset: 1024, 336 slots × 8 bytes = 2688 bytes / Base offset 1024, 336 créneaux × 8 octets = 2688 octets
- Slot layout: `[0]`=mode (0xFF=disabled), `[1]`=anim, `[2]`=(colorRandom&0x03)|((animSpeed-1)<<2), `[3]`=animBrightMin, `[4]`=animBrightMax, `[5]`=R, `[6]`=G, `[7]`=B

> **Breaking change / Changement incompatible**: EEPROM offsets 1024+ are overwritten. Recommend RAZ (reset all slots) after first flash. / Les offsets EEPROM à partir de 1024 sont écrasés. Faire un RAZ après le premier flash.

---

## FR/EN Interface Translation / Traduction de l'interface FR/EN

**EN** — The entire dashboard UI switches to French or English instantly when the user changes the **Language** dropdown in General Settings. ~100 translation keys per language covering all labels, buttons, card titles, status messages, scheduler grid day names, and confirm dialogs. No server-side cost: a single new endpoint (`/admin/langvalue`) returns the saved language index; all translation logic runs in the browser.

**FR** — L'ensemble de l'interface bascule en français ou en anglais instantanément quand l'utilisateur change la liste déroulante **Langue** dans les paramètres généraux. ~100 clés de traduction par langue couvrant tous les libellés, boutons, titres de cartes, messages d'état, noms de jours de la grille et boîtes de confirmation. Aucun coût côté serveur : un seul nouvel endpoint (`/admin/langvalue`) retourne l'index de langue sauvegardé ; toute la logique de traduction s'exécute dans le navigateur.

### Implementation / Implémentation

- **`Page_general.h`** — new `send_lang_value_html()` serving `/admin/langvalue` / nouveau `send_lang_value_html()` pour `/admin/langvalue`
- **`Page_index.h`** — `data-i18n` attributes on all static text; `I18N` dictionary (FR/EN); `T()` / `applyI18n()` / `initI18n()` helpers; `updatelang()` calls `applyI18n()` immediately; `loadGeneralSettings()` re-syncs `currentLang` after AJAX reload; all JS-generated strings use `T()` / attributs `data-i18n` sur tout le texte statique ; dictionnaire `I18N` (FR/EN) ; helpers `T()` / `applyI18n()` / `initI18n()` ; `updatelang()` appelle `applyI18n()` immédiatement ; `loadGeneralSettings()` resynchronise `currentLang` après rechargement AJAX ; toutes les chaînes JS générées utilisent `T()`
- **`TexTime.ino`** — registers `/admin/langvalue`; fixes `setAPssid()` (missing `APPassword` argument) / enregistre `/admin/langvalue` ; corrige `setAPssid()` (argument `APPassword` manquant)

---

## Other changes / Autres modifications

- **HSV color picker**: custom SV square + hue slider replaces native `<input type="color">`, in both General Settings and the scheduler rule editor / Sélecteur de couleur HSV personnalisé (carré SV + curseur de teinte) remplaçant `<input type="color">`, dans les paramètres généraux et dans l'éditeur de règles du programmateur
- **Animation controls**: speed, min/max brightness sliders (general settings + scheduler) / Contrôles d'animation : curseurs de vitesse et luminosité min/max
- **Tetris & Snake**: playable games accessible from the sidebar / Jeux Tetris et Snake accessibles depuis la barre latérale
- **5 new LED animation effects** / 5 nouveaux effets d'animation LED
- **WiFi/NTP bugfixes** / Correctifs WiFi/NTP

---

## Files changed / Fichiers modifiés

- `global.h` : SCHEDULER_EEPROM_BASE, SCHEDULER_SLOT_SIZE, EEPROM_SIZE → 4096
- `TexTime.ino` : Page_scheduler.h include, new routes, `handleScheduler()` in loop(), `/admin/langvalue`, `setAPssid()` fix
- `Page_scheduler.h` : new file — full scheduler backend / nouveau fichier — backend complet du programmateur
- `Page_index.h` : scheduler UI + i18n + HSV picker + animation controls
- `Page_general.h` : `send_lang_value_html()`
- `Page_style.css.h` : scheduler grid styles + HSV picker styles / styles grille + styles sélecteur HSV
- `LedStrip.h`, `Page_tetris.h`, `Page_snake.h` : new animations + games / nouvelles animations + jeux
- `WiFiMgr.cpp`, `WiFiMgr.h`, `NTP.h`, `Page_network.h` : bugfixes

---

## Test plan / Plan de test

- [ ] Compile with `esp8266:esp8266:nodemcuv2` (verified: 50% flash, 94% IRAM) / Compiler avec `esp8266:esp8266:nodemcuv2` (vérifié : 50% flash, 94% IRAM)
- [ ] OTA flash and verify web interface loads / Flash OTA et vérifier le chargement de l'interface
- [ ] FR device → UI displays in French on load / Appareil en FR → interface en français au chargement
- [ ] Change Language to English → UI switches instantly, no reload / Changer Langue en anglais → basculement instantané sans rechargement
- [ ] Save → reload → language persists / Sauvegarder → recharger → la langue persiste
- [ ] All sections fully translated (General, Network, NTP, MQTT, Scheduler, Firmware) / Toutes les sections traduites
- [ ] Scheduler RAZ confirm dialog and day labels translated / Boîte de confirmation RAZ et noms de jours traduits
- [ ] Save/Saving/Saved/Error button states translated / États bouton Enregistrement/Enregistré/Erreur traduits
- [ ] Scheduler: create rules, paint grid, save, verify applies on next half-hour / Programmateur : créer des règles, peindre la grille, sauvegarder, vérifier l'application à la demi-heure suivante
- [ ] HSV picker: click swatch, drag SV square and hue slider, color updates live / Sélecteur HSV : cliquer la pastille, glisser carré SV et curseur teinte, couleur mise à jour en temps réel
- [ ] Tetris and Snake load via sidebar links / Tetris et Snake accessibles via la barre latérale
- [ ] RAZ after first flash (EEPROM breaking change) / RAZ après le premier flash (changement incompatible EEPROM)

Closes #7
Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
